### PR TITLE
fix unstable data api base path

### DIFF
--- a/mcp-server/pkg/client/provider.go
+++ b/mcp-server/pkg/client/provider.go
@@ -13,7 +13,7 @@ import (
 	"github.com/prometheus/client_golang/api"
 
 	"github.com/chronosphereio/mcp-server/generated/configv1/configv1"
-	"github.com/chronosphereio/mcp-server/generated/dataunstable/dataunstable/data_unstable"
+	"github.com/chronosphereio/mcp-server/generated/dataunstable/dataunstable"
 	"github.com/chronosphereio/mcp-server/mcp-server/pkg/tools"
 )
 
@@ -48,12 +48,12 @@ func (c *Provider) PrometheusPromClient(session tools.Session) (api.Client, erro
 	return c.prometheusClientForBasePath(session, "/app/prom")
 }
 
-func (c *Provider) DataUnstableClient(session tools.Session) (data_unstable.ClientService, error) {
-	t, err := c.transportForSession(session, "/api")
+func (c *Provider) DataUnstableClient(session tools.Session) (*dataunstable.DataUnstableAPI, error) {
+	t, err := c.transportForSession(session, "/")
 	if err != nil {
 		return nil, fmt.Errorf("could not construct Chronosphere data unstable API client: %v", err)
 	}
-	return data_unstable.New(t, strfmt.Default), nil
+	return dataunstable.New(t, strfmt.Default), nil
 }
 
 func (c *Provider) prometheusClientForBasePath(session tools.Session, basePath string) (api.Client, error) {

--- a/mcp-server/pkg/tools/events/events.go
+++ b/mcp-server/pkg/tools/events/events.go
@@ -65,7 +65,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				if err != nil {
 					return nil, err
 				}
-				resp, err := api.ListEvents(queryParams)
+				resp, err := api.DataUnstable.ListEvents(queryParams)
 				if err != nil {
 					return nil, fmt.Errorf("failed to list events: %s", err)
 				}
@@ -83,7 +83,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				if err != nil {
 					return nil, err
 				}
-				resp, err := api.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
+				resp, err := api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
 					Field: ptr.To(string(models.DataunstableEventFieldCATEGORYEVENTFIELD)),
 				})
 
@@ -100,7 +100,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				}
 				eventsMetadata.Categories = resp.Payload.Values
 
-				resp, err = api.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
+				resp, err = api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
 					Field: ptr.To(string(models.DataunstableEventFieldSOURCEEVENTFIELD)),
 				})
 				if err != nil {
@@ -109,7 +109,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 
 				eventsMetadata.Sources = resp.Payload.Values
 
-				resp, err = api.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
+				resp, err = api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
 					Field: ptr.To(string(models.DataunstableEventFieldTYPEEVENTFIELD)),
 				})
 				if err != nil {
@@ -118,7 +118,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 
 				eventsMetadata.Types = resp.Payload.Values
 
-				resp, err = api.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
+				resp, err = api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
 					Field: ptr.To(string(models.DataunstableEventFieldLABELNAMEEVENTFIELD)),
 				})
 				if err != nil {
@@ -127,7 +127,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 
 				eventsMetadata.LabelNames = resp.Payload.Values
 
-				resp, err = api.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
+				resp, err = api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
 					Field: ptr.To(string(models.DataunstableEventFieldLABELNAMEEVENTFIELD)),
 				})
 				if err != nil {
@@ -136,7 +136,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 
 				eventsMetadata.LabelNames = resp.Payload.Values
 
-				resp, err = api.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
+				resp, err = api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
 					Field: ptr.To(string(models.DataunstableEventFieldLENSSERVICEEVENTFIELD)),
 				})
 				if err != nil {
@@ -166,7 +166,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				if err != nil {
 					return nil, err
 				}
-				resp, err := api.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
+				resp, err := api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
 					LabelName: ptr.To(labelName),
 					Field:     ptr.To(string(models.DataunstableEventFieldLABELNAMEEVENTFIELD)),
 				})

--- a/mcp-server/pkg/tools/logs/logs.go
+++ b/mcp-server/pkg/tools/logs/logs.go
@@ -71,7 +71,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				if err != nil {
 					return nil, err
 				}
-				resp, err := logsAPI.ListLogs(queryParams)
+				resp, err := logsAPI.DataUnstable.ListLogs(queryParams)
 				if err != nil {
 					return nil, fmt.Errorf("failed to list logs: %s", err)
 				}
@@ -102,7 +102,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				if err != nil {
 					return nil, err
 				}
-				resp, err := logsAPI.ListLogs(queryParams)
+				resp, err := logsAPI.DataUnstable.ListLogs(queryParams)
 				if err != nil {
 					return nil, fmt.Errorf("failed to query log by ID: %s", err)
 				}
@@ -153,7 +153,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				if err != nil {
 					return nil, err
 				}
-				resp, err := logsAPI.GetLogHistogram(queryParams)
+				resp, err := logsAPI.DataUnstable.GetLogHistogram(queryParams)
 				if err != nil {
 					return nil, fmt.Errorf("failed to get log histogram: %s", err)
 				}
@@ -203,7 +203,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				if err != nil {
 					return nil, err
 				}
-				resp, err := logsAPI.ListLogFieldNames(queryParams)
+				resp, err := logsAPI.DataUnstable.ListLogFieldNames(queryParams)
 				if err != nil {
 					return nil, fmt.Errorf("failed to list log field names: %s", err)
 				}
@@ -262,7 +262,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				if err != nil {
 					return nil, err
 				}
-				resp, err := logsAPI.ListLogFieldValues(queryParams)
+				resp, err := logsAPI.DataUnstable.ListLogFieldValues(queryParams)
 				if err != nil {
 					return nil, fmt.Errorf("failed to list log field values: %s", err)
 				}

--- a/mcp-server/pkg/tools/traces/traces.go
+++ b/mcp-server/pkg/tools/traces/traces.go
@@ -95,7 +95,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				if err != nil {
 					return nil, err
 				}
-				resp, err := api.ListTraces(queryParams)
+				resp, err := api.DataUnstable.ListTraces(queryParams)
 				if err != nil {
 					return nil, fmt.Errorf("failed to list traces: %s", err)
 				}


### PR DESCRIPTION
* Fix the base path for the unstable API.
* Reference the *DataUnstableAPI struct instead of the interface to be
  consistent with how we use the config API.