### PR TITLE
Enable stdio transport by default

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,8 @@ server:
       address: 0.0.0.0:8080
       #baseURL: http://host.docker.internal:8080
       baseURL: http://0.0.0.0:8080
+    stdio:
+      enabled: true
 
   tools:
     # List of tools to disable if you don't want to serve them to the client/host.

--- a/mcp-server/pkg/cmd/root.go
+++ b/mcp-server/pkg/cmd/root.go
@@ -59,7 +59,7 @@ func New() *cobra.Command {
 func provideLogger(verboseLogging bool) (*zap.Logger, error) {
 	tmpDir := os.TempDir()
 	loggerCfg := zap.NewProductionConfig()
-	loggerCfg.OutputPaths = []string{"stdout", path.Join(tmpDir, "mcp_server.log")}
+	loggerCfg.OutputPaths = []string{"stderr", path.Join(tmpDir, "mcp_server.log")}
 	loggerCfg.ErrorOutputPaths = []string{"stderr", path.Join(tmpDir, "mcp_server_error.log")}
 	if verboseLogging {
 		loggerCfg.Level = zap.NewAtomicLevelAt(zap.DebugLevel)

--- a/mcp-server/pkg/config/config.go
+++ b/mcp-server/pkg/config/config.go
@@ -3,15 +3,12 @@ package config
 
 import (
 	"bytes"
-	"log"
 	"os"
 
 	"go.uber.org/config"
 )
 
 func ParseFile(path string) (config.Provider, error) {
-	log.Printf("Loading config file from %q\n", path)
-
 	data, err := os.ReadFile(path) //nolint:gosec
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
* Enabling stdio in config.yaml since claude desktop uses that.
* Pipe logs to stderr so it doesn't interfere with stdio transport.
