### PR TITLE
bump mcp-go to 0.29.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/go-openapi/swag v0.23.0
 	github.com/go-openapi/validate v0.24.0
-	github.com/mark3labs/mcp-go v0.26.0
+	github.com/mark3labs/mcp-go v0.29.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/common v0.61.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/mark3labs/mcp-go v0.26.0 h1:xz/Kv1cHLYovF8txv6btBM39/88q3YOjnxqhi51jB0w=
-github.com/mark3labs/mcp-go v0.26.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
+github.com/mark3labs/mcp-go v0.29.0 h1:sH1NBcumKskhxqYzhXfGc201D7P76TVXiT0fGVhabeI=
+github.com/mark3labs/mcp-go v0.29.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/mcp-server/pkg/mcpserver/mcpserver.go
+++ b/mcp-server/pkg/mcpserver/mcpserver.go
@@ -84,7 +84,7 @@ func (s *Server) SSEServer(baseURL string, options ...server.SSEOption) *server.
 		append(options,
 			[]server.SSEOption{
 				server.WithBaseURL(baseURL),
-				server.WithSSEContextFunc(func(ctx context.Context, r *http.Request) context.Context {
+				server.WithHTTPContextFunc(func(ctx context.Context, r *http.Request) context.Context {
 					authValue := strings.ReplaceAll(r.Header.Get("Authorization"), "Bearer ", "")
 					return authcontext.SetSessionAPIToken(ctx, authValue)
 				}),

--- a/mcp-server/pkg/tools/pkg/params/params.go
+++ b/mcp-server/pkg/tools/pkg/params/params.go
@@ -31,7 +31,7 @@ type ParamParser[T any] func(param interface{}) (T, error)
 // It returns a ParamResult which contains either the parsed value or error information
 func parse[T any](request mcp.CallToolRequest, key string, required bool, defaultValue T, parser ParamParser[T]) (T, error) {
 	// Check if the parameter exists
-	param, ok := request.Params.Arguments[key]
+	param, ok := request.GetArguments()[key]
 	if !ok {
 		if required {
 			var zero T
@@ -208,7 +208,7 @@ func Object[T any](request mcp.CallToolRequest, key string, required bool, defau
 
 // ObjectArray parses an array of objects parameter and returns the value and any tool result error
 func ObjectArray[T any](request mcp.CallToolRequest, key string, required bool) ([]T, error) {
-	args := request.Params.Arguments
+	args := request.GetArguments()
 	arrayRaw, ok := args[key]
 	if !ok {
 		if required {


### PR DESCRIPTION
There's some better argument binding ergonomics we might want to use.