### PR TITLE
refactor command line flags

### DIFF
--- a/mcp-server/pkg/cmd/flags.go
+++ b/mcp-server/pkg/cmd/flags.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	// ChronosphereOrgNameKey is the environment variable that specifies the Chronosphere customer organization
+	ChronosphereOrgNameKey = "CHRONOSPHERE_ORG_NAME"
+	// ChronosphereAPITokenKey is the environment variable that specifies the Chronosphere API token
+	ChronosphereAPITokenKey = "CHRONOSPHERE_API_TOKEN"
+	apiURLFormat            = "https://%s.chronosphere.io"
+)
+
+type Flags struct {
+	apiToken         string
+	apiTokenFileName string
+	orgName          string
+	apiURL           string
+	ConfigFilePath   string
+	VerboseLogging   bool
+}
+
+// AddFlags adds client flags to a Cobra command.
+func (f *Flags) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.ConfigFilePath, "config-file", "c", "", "The YAML file containing configuration parameters")
+	cmd.Flags().BoolVarP(&f.VerboseLogging, "verbose", "v", false, "Whether verbose logging, including logging requests and responses, should be enabled")
+	cmd.Flags().StringVar(&f.apiToken, "api-token", "", "The client API token used to authenticate to user. Mutally exclusive with --api-token-filename. If both --api-token and --api-token-filename are unset, the "+ChronosphereAPITokenKey+" environment variable is used.")
+	cmd.Flags().StringVar(&f.apiTokenFileName, "api-token-filename", "", "A file containing the API token used for authentication. Mutally exclusive with --api-token. If both --api-token and --api-token-filename are unset, the "+ChronosphereAPITokenKey+" environment variable is used.")
+	cmd.Flags().StringVar(&f.orgName, "org-name", "", "The name of your team's Chronosphere organization. Defaults to "+ChronosphereOrgNameKey+" environment variable.")
+
+	cmd.Flags().StringVar(&f.apiURL, "api-url", f.apiURL, "The URL of the Chronosphere API. Defaults to https://<organization>.chronosphere.io/api.")
+	cmd.Flags().MarkHidden("api-url") //nolint:errcheck
+}
+
+func (f *Flags) GetAPIToken() (string, error) {
+	if f.apiToken != "" && f.apiTokenFileName != "" {
+		return "", errors.New("only one of --api-token and --api-token-filename can be set")
+	}
+
+	if f.apiToken != "" {
+		return f.apiToken, nil
+	}
+
+	if f.apiTokenFileName != "" {
+		b, err := os.ReadFile(f.apiTokenFileName)
+		if err != nil {
+			return "", fmt.Errorf("reading api token from file %s: %w", f.apiTokenFileName, err)
+		}
+		return strings.TrimSpace(string(b)), nil
+	}
+
+	if key := os.Getenv(ChronosphereAPITokenKey); key != "" {
+		return key, nil
+	}
+
+	return "", errors.New("api token must be provided as a flag, via the " + ChronosphereAPITokenKey + " environment variable, or by setting a file with the --api-token-filename flag")
+}
+
+func (f *Flags) GetAPIURL() (string, error) {
+	if f.apiURL != "" {
+		return f.apiURL, nil
+	}
+	if f.orgName == "" {
+		if f.orgName = os.Getenv(ChronosphereOrgNameKey); f.orgName == "" {
+			return "", errors.New("org name must be provided as a flag or via the " + ChronosphereOrgNameKey + " environment variable")
+		}
+	}
+	return fmt.Sprintf(apiURLFormat, f.orgName), nil
+}

--- a/mcp-server/pkg/mcpserverfx/mcpserverfx.go
+++ b/mcp-server/pkg/mcpserverfx/mcpserverfx.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"go.uber.org/config"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 
-	"github.com/chronosphereio/mcp-server/mcp-server/pkg/client"
 	"github.com/chronosphereio/mcp-server/mcp-server/pkg/mcpserver"
 	"github.com/chronosphereio/mcp-server/mcp-server/pkg/tools"
 )
@@ -25,11 +23,9 @@ type params struct {
 	fx.In
 	LifeCycle fx.Lifecycle
 
-	Config         *Config
-	ClientProvider *client.Provider
-	ConfigProvider config.Provider
-	Logger         *zap.Logger
-	ToolGroups     []tools.MCPTools `group:"mcp_tools"`
+	Config     *Config
+	Logger     *zap.Logger
+	ToolGroups []tools.MCPTools `group:"mcp_tools"`
 }
 
 type ToolsConfig struct {


### PR DESCRIPTION
We were re-using flags from chronoctl-core which made it somewhat hard
to extend. It also couples transport and client/APIs with flags which we
mostly don't use.

This is a partial fork of the chronoctl flags struct with everything we
don't use removed. Having control of this will make it a bit easier to
extend.