### PR TITLE
return log explorer link along with log queries

### DIFF
--- a/mcp-server/pkg/mcpserver/mcpserver.go
+++ b/mcp-server/pkg/mcpserver/mcpserver.go
@@ -139,7 +139,7 @@ func (t *loggingTool) mustHandle(ctx context.Context, request mcp.CallToolReques
 
 	var toolResult mcp.CallToolResult
 	if resp.ChronosphereLink != "" {
-		toolResult.Content = append(toolResult.Content, mcp.NewTextContent("link: "+resp.ChronosphereLink))
+		toolResult.Content = append(toolResult.Content, mcp.NewTextContent("link to chronosphere: "+resp.ChronosphereLink))
 	}
 	if len(resp.ImageContent) > 0 {
 		encoded := base64.StdEncoding.EncodeToString(resp.ImageContent)

--- a/mcp-server/pkg/mcpserver/mcpserver_test.go
+++ b/mcp-server/pkg/mcpserver/mcpserver_test.go
@@ -58,7 +58,7 @@ func TestLoggingTool_mustHandle(t *testing.T) {
 				},
 			},
 			expectedContent: []mcp.Content{
-				mcp.NewTextContent("link: https://chronosphere.io"),
+				mcp.NewTextContent("link to chronosphere: https://chronosphere.io"),
 				mcp.NewTextContent(`{"data":"test"}`),
 			},
 		},

--- a/mcp-server/pkg/tools/logs/logs.go
+++ b/mcp-server/pkg/tools/logs/logs.go
@@ -4,6 +4,7 @@ package logs
 import (
 	"fmt"
 
+	"github.com/chronosphereio/mcp-server/pkg/links"
 	"github.com/go-openapi/strfmt"
 	"github.com/mark3labs/mcp-go/mcp"
 	"go.uber.org/zap"
@@ -20,14 +21,16 @@ var _ tools.MCPTools = (*Tools)(nil)
 type Tools struct {
 	logger         *zap.Logger
 	clientProvider *client.Provider
+	linkBuilder    *links.Builder
 }
 
-func NewTools(clientProvider *client.Provider, logger *zap.Logger) (*Tools, error) {
+func NewTools(clientProvider *client.Provider, logger *zap.Logger, linkBuilder *links.Builder) (*Tools, error) {
 	logger.Info("logging tool configured")
 
 	return &Tools{
 		logger:         logger,
 		clientProvider: clientProvider,
+		linkBuilder:    linkBuilder,
 	}, nil
 }
 
@@ -89,6 +92,10 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				// TODO: summarize logs before returning.
 				return &tools.Result{
 					JSONContent: resp,
+					ChronosphereLink: t.linkBuilder.LogExplorer().
+						WithQuery(query).
+						WithTimeRange(timeRange.Start, timeRange.End).
+						String(),
 				}, nil
 			},
 		},
@@ -138,6 +145,10 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 
 				return &tools.Result{
 					JSONContent: resp,
+					ChronosphereLink: t.linkBuilder.LogExplorer().
+						WithQuery(query).
+						WithTimeRange(timeRange.Start, timeRange.End).
+						String(),
 				}, nil
 			},
 		},
@@ -167,6 +178,9 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				}
 				return &tools.Result{
 					JSONContent: resp,
+					ChronosphereLink: t.linkBuilder.LogExplorer().
+						WithQuery(fmt.Sprintf("logID=%q", id)).
+						String(),
 				}, nil
 			},
 		},
@@ -219,6 +233,10 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 
 				return &tools.Result{
 					JSONContent: resp,
+					ChronosphereLink: t.linkBuilder.LogExplorer().
+						WithQuery(query).
+						WithTimeRange(timeRange.Start, timeRange.End).
+						String(),
 				}, nil
 			},
 		},
@@ -269,6 +287,10 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 
 				return &tools.Result{
 					JSONContent: resp,
+					ChronosphereLink: t.linkBuilder.LogExplorer().
+						WithQuery(query).
+						WithTimeRange(timeRange.Start, timeRange.End).
+						String(),
 				}, nil
 			},
 		},
@@ -328,6 +350,10 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 
 				return &tools.Result{
 					JSONContent: resp,
+					ChronosphereLink: t.linkBuilder.LogExplorer().
+						WithQuery(query).
+						WithTimeRange(timeRange.Start, timeRange.End).
+						String(),
 				}, nil
 			},
 			// TODO: Implement autocomplete requests.

--- a/pkg/links/links.go
+++ b/pkg/links/links.go
@@ -8,6 +8,16 @@ import (
 	"time"
 )
 
+type Builder struct {
+	chronosphereURL string
+}
+
+func NewBuilder(chronosphereURL string) *Builder {
+	return &Builder{
+		chronosphereURL: chronosphereURL,
+	}
+}
+
 // LogExplorerBuilder builds links to the Chronosphere log explorer
 type LogExplorerBuilder struct {
 	chronosphereURL string
@@ -18,9 +28,9 @@ type LogExplorerBuilder struct {
 }
 
 // LogExplorer creates a new LogExplorerBuilder for the specified chronosphereURL
-func LogExplorer(chronosphereURL string) *LogExplorerBuilder {
+func (b *Builder) LogExplorer() *LogExplorerBuilder {
 	return &LogExplorerBuilder{
-		chronosphereURL: chronosphereURL,
+		chronosphereURL: b.chronosphereURL,
 		visualization:   "list", // default visualization
 	}
 }

--- a/pkg/links/links_test.go
+++ b/pkg/links/links_test.go
@@ -9,6 +9,7 @@ func TestLogExplorer(t *testing.T) {
 	start := time.Unix(1747887246, 0)
 	end := time.Unix(1747890846, 0)
 
+	builder := NewBuilder("https://rc.chronosphere.io")
 	tests := []struct {
 		name     string
 		builder  *LogExplorerBuilder
@@ -16,22 +17,22 @@ func TestLogExplorer(t *testing.T) {
 	}{
 		{
 			name:     "basic log explorer",
-			builder:  LogExplorer("https://rc.chronosphere.io"),
+			builder:  builder.LogExplorer(),
 			expected: "https://rc.chronosphere.io/logs/explorer?visualization=list",
 		},
 		{
 			name:     "with query",
-			builder:  LogExplorer("https://rc.chronosphere.io").WithQuery(`service="chronogateway"`),
+			builder:  builder.LogExplorer().WithQuery(`service="chronogateway"`),
 			expected: "https://rc.chronosphere.io/logs/explorer?query=service%3D%22chronogateway%22&visualization=list",
 		},
 		{
 			name:     "with time range and query",
-			builder:  LogExplorer("https://rc.chronosphere.io").WithTimeRange(start, end).WithQuery(`service="chronogateway"`),
+			builder:  builder.LogExplorer().WithTimeRange(start, end).WithQuery(`service="chronogateway"`),
 			expected: "https://rc.chronosphere.io/logs/explorer?end=1747890846000&query=service%3D%22chronogateway%22&start=1747887246000&visualization=list",
 		},
 		{
 			name:     "with different visualization",
-			builder:  LogExplorer("https://rc.chronosphere.io").WithVisualization("chart"),
+			builder:  builder.LogExplorer().WithVisualization("chart"),
 			expected: "https://rc.chronosphere.io/logs/explorer?visualization=chart",
 		},
 	}


### PR DESCRIPTION
Returning a chronosphere link when using log related tools to help the llm direct the user to chronosphere's log explorer.
