### PR TITLE
fix invalid parameter names

### DIFF
--- a/mcp-server/pkg/generated/tools/configv1/dashboards.gen.go
+++ b/mcp-server/pkg/generated/tools/configv1/dashboards.gen.go
@@ -65,11 +65,11 @@ func ListDashboards(clientProvider *client.Provider, logger *zap.Logger) tools.M
 				mcp.Description("Filters results by name, where any Dashboard with a matching name in the given list (and matches all other filters) is returned."),
 			),
 
-			mcp.WithNumber("page.max_size",
+			mcp.WithNumber("page_max_size",
 				mcp.Description("Page size preference (i.e. how many items are returned in the next page). If zero, the server will use a default. Regardless of what size is given, clients must never assume how many items will be returned."),
 			),
 
-			mcp.WithString("page.token",
+			mcp.WithString("page_token",
 				mcp.Description("Opaque page token identifying which page to request. An empty token identifies the first page."),
 			),
 
@@ -93,12 +93,12 @@ func ListDashboards(clientProvider *client.Provider, logger *zap.Logger) tools.M
 				return nil, err
 			}
 
-			pageMaxSize, err := params.Int(request, "page.max_size", false, 0)
+			pageMaxSize, err := params.Int(request, "page_max_size", false, 0)
 			if err != nil {
 				return nil, err
 			}
 
-			pageToken, err := params.String(request, "page.token", false, "")
+			pageToken, err := params.String(request, "page_token", false, "")
 			if err != nil {
 				return nil, err
 			}

--- a/mcp-server/pkg/generated/tools/configv1/monitors.gen.go
+++ b/mcp-server/pkg/generated/tools/configv1/monitors.gen.go
@@ -65,11 +65,11 @@ func ListMonitors(clientProvider *client.Provider, logger *zap.Logger) tools.MCP
 				mcp.Description("Filters results by name, where any Monitor with a matching name in the given list (and matches all other filters) is returned."),
 			),
 
-			mcp.WithNumber("page.max_size",
+			mcp.WithNumber("page_max_size",
 				mcp.Description("Page size preference (i.e. how many items are returned in the next page). If zero, the server will use a default. Regardless of what size is given, clients must never assume how many items will be returned."),
 			),
 
-			mcp.WithString("page.token",
+			mcp.WithString("page_token",
 				mcp.Description("Opaque page token identifying which page to request. An empty token identifies the first page."),
 			),
 
@@ -97,12 +97,12 @@ func ListMonitors(clientProvider *client.Provider, logger *zap.Logger) tools.MCP
 				return nil, err
 			}
 
-			pageMaxSize, err := params.Int(request, "page.max_size", false, 0)
+			pageMaxSize, err := params.Int(request, "page_max_size", false, 0)
 			if err != nil {
 				return nil, err
 			}
 
-			pageToken, err := params.String(request, "page.token", false, "")
+			pageToken, err := params.String(request, "page_token", false, "")
 			if err != nil {
 				return nil, err
 			}

--- a/mcp-server/pkg/generated/tools/configv1/slos.gen.go
+++ b/mcp-server/pkg/generated/tools/configv1/slos.gen.go
@@ -61,11 +61,11 @@ func ListSlos(clientProvider *client.Provider, logger *zap.Logger) tools.MCPTool
 				mcp.Description("Filters results by name, where any SLO with a matching name in the given list (and matches all other filters) is returned."),
 			),
 
-			mcp.WithNumber("page.max_size",
+			mcp.WithNumber("page_max_size",
 				mcp.Description("Page size preference (i.e. how many items are returned in the next page). If zero, the server will use a default. Regardless of what size is given, clients must never assume how many items will be returned."),
 			),
 
-			mcp.WithString("page.token",
+			mcp.WithString("page_token",
 				mcp.Description("Opaque page token identifying which page to request. An empty token identifies the first page."),
 			),
 
@@ -88,12 +88,12 @@ func ListSlos(clientProvider *client.Provider, logger *zap.Logger) tools.MCPTool
 				return nil, err
 			}
 
-			pageMaxSize, err := params.Int(request, "page.max_size", false, 0)
+			pageMaxSize, err := params.Int(request, "page_max_size", false, 0)
 			if err != nil {
 				return nil, err
 			}
 
-			pageToken, err := params.String(request, "page.token", false, "")
+			pageToken, err := params.String(request, "page_token", false, "")
 			if err != nil {
 				return nil, err
 			}

--- a/tools/cmd/mcpgen/generator.go
+++ b/tools/cmd/mcpgen/generator.go
@@ -117,7 +117,7 @@ func convertToolSpec(entityName string, action string, command *clispec.Command)
 	}
 	for _, param := range command.Parameters {
 		spec.Parameters = append(spec.Parameters, ParameterSpec{
-			Name:               param.Name,
+			Name:               inflect.Underscore(strings.Replace(param.Name, ".", "_", -1)),
 			GoName:             uncapitalize(camelCase(param.Name)),
 			SwaggerGoFieldName: acronymReplace(camelCase(param.Name)),
 			Description:        param.Description,


### PR DESCRIPTION
page.max_size and page.token are invalid mcp parameter names according
to cursor, so changing the names to use underscore.