### PR TITLE
fix context forwarding in tools

### DIFF
--- a/mcp-server/pkg/generated/tools/configv1/dashboards.gen.go
+++ b/mcp-server/pkg/generated/tools/configv1/dashboards.gen.go
@@ -31,6 +31,8 @@ func GetDashboard(clientProvider *client.Provider, logger *zap.Logger) tools.MCP
 
 			queryParams := &dashboard.ReadDashboardParams{
 				Slug: slug,
+
+				Context: session.Context,
 			}
 
 			api, err := clientProvider.ConfigV1Client(session)
@@ -120,6 +122,8 @@ func ListDashboards(clientProvider *client.Provider, logger *zap.Logger) tools.M
 				PageToken: &pageToken,
 
 				Slugs: slugs,
+
+				Context: session.Context,
 			}
 
 			api, err := clientProvider.ConfigV1Client(session)

--- a/mcp-server/pkg/generated/tools/configv1/monitors.gen.go
+++ b/mcp-server/pkg/generated/tools/configv1/monitors.gen.go
@@ -31,6 +31,8 @@ func GetMonitor(clientProvider *client.Provider, logger *zap.Logger) tools.MCPTo
 
 			queryParams := &monitor.ReadMonitorParams{
 				Slug: slug,
+
+				Context: session.Context,
 			}
 
 			api, err := clientProvider.ConfigV1Client(session)
@@ -131,6 +133,8 @@ func ListMonitors(clientProvider *client.Provider, logger *zap.Logger) tools.MCP
 				Slugs: slugs,
 
 				TeamSlugs: teamSlugs,
+
+				Context: session.Context,
 			}
 
 			api, err := clientProvider.ConfigV1Client(session)

--- a/mcp-server/pkg/generated/tools/configv1/slos.gen.go
+++ b/mcp-server/pkg/generated/tools/configv1/slos.gen.go
@@ -31,6 +31,8 @@ func GetSlo(clientProvider *client.Provider, logger *zap.Logger) tools.MCPTool {
 
 			queryParams := &s_l_o.ReadSLOParams{
 				Slug: slug,
+
+				Context: session.Context,
 			}
 
 			api, err := clientProvider.ConfigV1Client(session)
@@ -120,6 +122,8 @@ func ListSlos(clientProvider *client.Provider, logger *zap.Logger) tools.MCPTool
 				ServiceSlugs: serviceSlugs,
 
 				Slugs: slugs,
+
+				Context: session.Context,
 			}
 
 			api, err := clientProvider.ConfigV1Client(session)

--- a/mcp-server/pkg/tools/events/events.go
+++ b/mcp-server/pkg/tools/events/events.go
@@ -85,7 +85,8 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 					return nil, err
 				}
 				resp, err := api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
-					Field: ptr.To(string(models.DataunstableEventFieldCATEGORYEVENTFIELD)),
+					Context: session.Context,
+					Field:   ptr.To(string(models.DataunstableEventFieldCATEGORYEVENTFIELD)),
 				})
 
 				eventsMetadata := struct {
@@ -102,7 +103,8 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				eventsMetadata.Categories = resp.Payload.Values
 
 				resp, err = api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
-					Field: ptr.To(string(models.DataunstableEventFieldSOURCEEVENTFIELD)),
+					Context: session.Context,
+					Field:   ptr.To(string(models.DataunstableEventFieldSOURCEEVENTFIELD)),
 				})
 				if err != nil {
 					return nil, fmt.Errorf("failed to get sources for events: %s", err)
@@ -111,7 +113,8 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				eventsMetadata.Sources = resp.Payload.Values
 
 				resp, err = api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
-					Field: ptr.To(string(models.DataunstableEventFieldTYPEEVENTFIELD)),
+					Context: session.Context,
+					Field:   ptr.To(string(models.DataunstableEventFieldTYPEEVENTFIELD)),
 				})
 				if err != nil {
 					return nil, fmt.Errorf("failed to get types for events: %s", err)
@@ -120,7 +123,8 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				eventsMetadata.Types = resp.Payload.Values
 
 				resp, err = api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
-					Field: ptr.To(string(models.DataunstableEventFieldLABELNAMEEVENTFIELD)),
+					Context: session.Context,
+					Field:   ptr.To(string(models.DataunstableEventFieldLABELNAMEEVENTFIELD)),
 				})
 				if err != nil {
 					return nil, fmt.Errorf("failed to get label names for events: %s", err)
@@ -129,7 +133,8 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				eventsMetadata.LabelNames = resp.Payload.Values
 
 				resp, err = api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
-					Field: ptr.To(string(models.DataunstableEventFieldLABELNAMEEVENTFIELD)),
+					Context: session.Context,
+					Field:   ptr.To(string(models.DataunstableEventFieldLABELNAMEEVENTFIELD)),
 				})
 				if err != nil {
 					return nil, fmt.Errorf("failed to get label names for events: %s", err)
@@ -138,7 +143,8 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				eventsMetadata.LabelNames = resp.Payload.Values
 
 				resp, err = api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
-					Field: ptr.To(string(models.DataunstableEventFieldLENSSERVICEEVENTFIELD)),
+					Context: session.Context,
+					Field:   ptr.To(string(models.DataunstableEventFieldLENSSERVICEEVENTFIELD)),
 				})
 				if err != nil {
 					return nil, fmt.Errorf("failed to get label names for events: %s", err)
@@ -168,6 +174,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 					return nil, err
 				}
 				resp, err := api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
+					Context:   session.Context,
 					LabelName: ptr.To(labelName),
 					Field:     ptr.To(string(models.DataunstableEventFieldLABELNAMEEVENTFIELD)),
 				})

--- a/mcp-server/pkg/tools/traces/traces.go
+++ b/mcp-server/pkg/tools/traces/traces.go
@@ -75,6 +75,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				}
 
 				queryParams := &data_unstable.ListTracesParams{
+					Context:   session.Context,
 					StartTime: (*strfmt.DateTime)(ptr.To(timeRange.Start)),
 					EndTime:   (*strfmt.DateTime)(ptr.To(timeRange.End)),
 				}

--- a/tools/cmd/mcpgen/tmpl/entity_tool.go.tmpl
+++ b/tools/cmd/mcpgen/tmpl/entity_tool.go.tmpl
@@ -49,6 +49,7 @@ func {{ $toolSpec.CamelName }}(clientProvider *client.Provider, logger *zap.Logg
                     {{$param.SwaggerGoFieldName}}: {{$param.GoName -}},
                 {{end -}}
             {{ end }}
+                Context: session.Context,
             }
 
 			api, err := clientProvider.ConfigV1Client(session)


### PR DESCRIPTION
Must pass context to swagger API calls or things like tracing and auth
middleware won't work.