### PR TITLE
refactor outgoing transport for auth context

### DIFF
--- a/mcp-server/pkg/authcontext/middleware.go
+++ b/mcp-server/pkg/authcontext/middleware.go
@@ -1,0 +1,30 @@
+package authcontext
+
+import "net/http"
+
+// RoundTripper wraps an http.RoundTripper and adds an Authorization header.
+type RoundTripper struct {
+	token     string
+	transport http.RoundTripper
+}
+
+func NewRoundTripper(base http.RoundTripper, token string) *RoundTripper {
+	return &RoundTripper{
+		token:     token,
+		transport: base,
+	}
+}
+
+func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone the request to avoid modifying the original.
+	req2 := req.Clone(req.Context())
+
+	if authToken := FetchSessionAPIToken(req.Context()); authToken != "" {
+		// forward the api token from context if available
+		req2.Header.Set("Authorization", "Bearer "+authToken)
+	} else if r.token != "" {
+		req2.Header.Set("Authorization", "Bearer "+r.token)
+	}
+
+	return r.transport.RoundTrip(req2)
+}

--- a/mcp-server/pkg/client/transport.go
+++ b/mcp-server/pkg/client/transport.go
@@ -1,0 +1,76 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	xswagger "github.com/chronosphereio/chronoctl-core/src/x/swagger"
+	"github.com/chronosphereio/mcp-server/mcp-server/pkg/authcontext"
+	"github.com/chronosphereio/mcp-server/pkg/version"
+	httpruntime "github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
+)
+
+// Component is a value that indicates the part of the CLI that is invoking an
+// API. This is used to set the User-Agent header when making requests to the Chronosphere API.
+type Component string
+
+// swaggerRuntimeConfig is a struct that contains the configuration for creating a new HTTP transport
+type swaggerRuntimeConfig struct {
+	component Component
+	apiURL    string
+	allowHTTP bool
+	authToken string
+}
+
+func newRoundTripper(base http.RoundTripper, component Component, authToken string) http.RoundTripper {
+	return roundTripperFn(func(req *http.Request) (*http.Response, error) {
+		req = req.Clone(req.Context())
+		req.Header.Set("User-Agent", fmt.Sprintf("%s/%v-%v", component, version.Version, version.GitCommit))
+		return authcontext.NewRoundTripper(base, authToken).RoundTrip(req)
+	})
+}
+
+// New creates a new HTTP transport that can communicate with the Chronosphere API.
+func newSwaggerRuntime(config swaggerRuntimeConfig) (*httptransport.Runtime, error) {
+	apiURL, err := url.Parse(config.apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse URL of Chronosphere URL: %v", err)
+	}
+
+	var schemes []string
+	switch apiURL.Scheme {
+	case "https":
+		schemes = []string{"https"}
+	case "http":
+		if !config.allowHTTP {
+			return nil, errors.New("the scheme of the API URL is HTTP but the --allow-http flag was not set")
+		}
+		schemes = []string{"http"}
+	default:
+		// If the client didn't specify a scheme in the URL just use the API client's default
+		// by passing an empty slice to the transport constructor.
+	}
+
+	transport := httptransport.New(apiURL.Host, apiURL.Path, schemes)
+
+	transport.Transport = xswagger.WithRequestIDTrailerTransport(
+		newRoundTripper(transport.Transport, config.component, config.authToken),
+	)
+	transport.Consumers[httpruntime.JSONMime] = xswagger.JSONConsumer()
+	transport.Consumers[httpruntime.HTMLMime] = xswagger.TextConsumer()
+	transport.Consumers[httpruntime.TextMime] = xswagger.TextConsumer()
+	transport.Consumers["*/*"] = xswagger.TextConsumer() // backup, default consumer.
+
+	return transport, nil
+}
+
+type roundTripperFn func(req *http.Request) (*http.Response, error)
+
+var _ http.RoundTripper = roundTripperFn(nil)
+
+func (fn roundTripperFn) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}


### PR DESCRIPTION
The way we handle auth is a little awkward. We reuse the swagger
transport from chronoctl for both swagger requests and non-swagger
requests (prom). We also forward the auth token by extracting the bearer
token from a dummy request and then set an api-token header which 
might be a legacy chronoctl thing. 

This attempts to clean that up by partially forking the transport from
chronoctl to allow us to separate out a base round tripper used for both
prom and swagger and creating an auth forwarding round tripper
middleware that will allows us to greatly reduce the number of places we have
to deal with the auth token.