### PR TITLE
replace session with context

### DIFF
--- a/mcp-server/pkg/client/provider.go
+++ b/mcp-server/pkg/client/provider.go
@@ -13,7 +13,6 @@ import (
 	"github.com/chronosphereio/mcp-server/generated/configv1/configv1"
 	"github.com/chronosphereio/mcp-server/generated/dataunstable/dataunstable"
 	"github.com/chronosphereio/mcp-server/generated/stateunstable/stateunstable"
-	"github.com/chronosphereio/mcp-server/mcp-server/pkg/tools"
 )
 
 var (
@@ -33,8 +32,8 @@ func NewProvider(apiURL, apiToken string) (*Provider, error) {
 }
 
 // ConfigV1Client creates a new client to hit configv1 APIs.
-func (c *Provider) ConfigV1Client(session tools.Session) (*configv1.ConfigV1API, error) {
-	t, err := c.transportForSession(session, "")
+func (c *Provider) ConfigV1Client() (*configv1.ConfigV1API, error) {
+	t, err := c.transportForSession("")
 	if err != nil {
 		return nil, fmt.Errorf("could not construct Chronosphere config v1 API client: %v", err)
 	}
@@ -42,18 +41,18 @@ func (c *Provider) ConfigV1Client(session tools.Session) (*configv1.ConfigV1API,
 }
 
 // PrometheusDataClient creates a new client to hit Prometheus APIs.
-func (c *Provider) PrometheusDataClient(session tools.Session) (api.Client, error) {
-	return c.prometheusClientForBasePath(session, "/data/metrics")
+func (c *Provider) PrometheusDataClient() (api.Client, error) {
+	return c.prometheusClientForBasePath("/data/metrics")
 }
 
 // PrometheusPromClient creates a new client to hit Prometheus APIs.
-func (c *Provider) PrometheusPromClient(session tools.Session) (api.Client, error) {
-	return c.prometheusClientForBasePath(session, "/app/prom")
+func (c *Provider) PrometheusPromClient() (api.Client, error) {
+	return c.prometheusClientForBasePath("/app/prom")
 }
 
 // DataUnstableClient creates a new client to hit data unstable APIs.
-func (c *Provider) DataUnstableClient(session tools.Session) (*dataunstable.DataUnstableAPI, error) {
-	t, err := c.transportForSession(session, "/")
+func (c *Provider) DataUnstableClient() (*dataunstable.DataUnstableAPI, error) {
+	t, err := c.transportForSession("/")
 	if err != nil {
 		return nil, fmt.Errorf("could not construct Chronosphere data unstable API client: %v", err)
 	}
@@ -61,8 +60,8 @@ func (c *Provider) DataUnstableClient(session tools.Session) (*dataunstable.Data
 }
 
 // StateUnstableClient creates a new client to hit state unstable APIs.
-func (c *Provider) StateUnstableClient(session tools.Session) (*stateunstable.StateUnstableAPI, error) {
-	t, err := c.transportForSession(session, "/")
+func (c *Provider) StateUnstableClient() (*stateunstable.StateUnstableAPI, error) {
+	t, err := c.transportForSession("/")
 	if err != nil {
 		return nil, fmt.Errorf("could not construct Chronosphere state unstable API client: %v", err)
 	}
@@ -71,12 +70,12 @@ func (c *Provider) StateUnstableClient(session tools.Session) (*stateunstable.St
 
 // TransportForSession creates a transport for the given session.
 // This is exposed for use by tools that need to create clients that aren't provided directly.
-func (c *Provider) TransportForSession(session tools.Session, basePath string) (*openapiclient.Runtime, error) {
-	return c.transportForSession(session, basePath)
+func (c *Provider) TransportForSession(basePath string) (*openapiclient.Runtime, error) {
+	return c.transportForSession(basePath)
 }
 
-func (c *Provider) prometheusClientForBasePath(session tools.Session, basePath string) (api.Client, error) {
-	t, err := c.transportForSession(session, basePath)
+func (c *Provider) prometheusClientForBasePath(basePath string) (api.Client, error) {
+	t, err := c.transportForSession(basePath)
 	if err != nil {
 		return nil, fmt.Errorf("could not construct Chronosphere Prometheus API transport: %v", err)
 	}
@@ -102,7 +101,7 @@ func (c *Provider) prometheusClientForBasePath(session tools.Session, basePath s
 	return cl, nil
 }
 
-func (c *Provider) transportForSession(_ tools.Session, basePath string) (*openapiclient.Runtime, error) {
+func (c *Provider) transportForSession(basePath string) (*openapiclient.Runtime, error) {
 	return newSwaggerRuntime(swaggerRuntimeConfig{
 		component: _component,
 		apiURL:    fmt.Sprintf("%s%s", c.apiURL, basePath),

--- a/mcp-server/pkg/generated/tools/configv1/dashboards.gen.go
+++ b/mcp-server/pkg/generated/tools/configv1/dashboards.gen.go
@@ -1,6 +1,7 @@
 package configv1
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -23,19 +24,19 @@ func GetDashboard(clientProvider *client.Provider, logger *zap.Logger) tools.MCP
 				mcp.Required(),
 			),
 		),
-		Handler: func(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 			slug, err := params.String(request, "slug", true, "")
 			if err != nil {
 				return nil, err
 			}
 
 			queryParams := &dashboard.ReadDashboardParams{
-				Slug: slug,
+				Context: ctx,
 
-				Context: session.Context,
+				Slug: slug,
 			}
 
-			api, err := clientProvider.ConfigV1Client(session)
+			api, err := clientProvider.ConfigV1Client()
 			if err != nil {
 				return nil, err
 			}
@@ -79,7 +80,7 @@ func ListDashboards(clientProvider *client.Provider, logger *zap.Logger) tools.M
 				mcp.Description("Filters results by slug, where any Dashboard with a matching slug in the given list (and matches all other filters) is returned."),
 			),
 		),
-		Handler: func(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 			collectionSlugs, err := params.StringArray(request, "collection_slugs", false, nil)
 			if err != nil {
 				return nil, err
@@ -111,6 +112,8 @@ func ListDashboards(clientProvider *client.Provider, logger *zap.Logger) tools.M
 			}
 
 			queryParams := &dashboard.ListDashboardsParams{
+				Context: ctx,
+
 				CollectionSlugs: collectionSlugs,
 
 				IncludeDashboardJSON: ptr.To(includeDashboardJson),
@@ -122,11 +125,9 @@ func ListDashboards(clientProvider *client.Provider, logger *zap.Logger) tools.M
 				PageToken: &pageToken,
 
 				Slugs: slugs,
-
-				Context: session.Context,
 			}
 
-			api, err := clientProvider.ConfigV1Client(session)
+			api, err := clientProvider.ConfigV1Client()
 			if err != nil {
 				return nil, err
 			}

--- a/mcp-server/pkg/generated/tools/configv1/monitors.gen.go
+++ b/mcp-server/pkg/generated/tools/configv1/monitors.gen.go
@@ -1,6 +1,7 @@
 package configv1
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -23,19 +24,19 @@ func GetMonitor(clientProvider *client.Provider, logger *zap.Logger) tools.MCPTo
 				mcp.Required(),
 			),
 		),
-		Handler: func(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 			slug, err := params.String(request, "slug", true, "")
 			if err != nil {
 				return nil, err
 			}
 
 			queryParams := &monitor.ReadMonitorParams{
-				Slug: slug,
+				Context: ctx,
 
-				Context: session.Context,
+				Slug: slug,
 			}
 
-			api, err := clientProvider.ConfigV1Client(session)
+			api, err := clientProvider.ConfigV1Client()
 			if err != nil {
 				return nil, err
 			}
@@ -83,7 +84,7 @@ func ListMonitors(clientProvider *client.Provider, logger *zap.Logger) tools.MCP
 				mcp.Description("Filter returned monitors by the teams that own the collections that they belong to."),
 			),
 		),
-		Handler: func(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 			bucketSlugs, err := params.StringArray(request, "bucket_slugs", false, nil)
 			if err != nil {
 				return nil, err
@@ -120,6 +121,8 @@ func ListMonitors(clientProvider *client.Provider, logger *zap.Logger) tools.MCP
 			}
 
 			queryParams := &monitor.ListMonitorsParams{
+				Context: ctx,
+
 				BucketSlugs: bucketSlugs,
 
 				CollectionSlugs: collectionSlugs,
@@ -133,11 +136,9 @@ func ListMonitors(clientProvider *client.Provider, logger *zap.Logger) tools.MCP
 				Slugs: slugs,
 
 				TeamSlugs: teamSlugs,
-
-				Context: session.Context,
 			}
 
-			api, err := clientProvider.ConfigV1Client(session)
+			api, err := clientProvider.ConfigV1Client()
 			if err != nil {
 				return nil, err
 			}

--- a/mcp-server/pkg/generated/tools/configv1/slos.gen.go
+++ b/mcp-server/pkg/generated/tools/configv1/slos.gen.go
@@ -1,6 +1,7 @@
 package configv1
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -23,19 +24,19 @@ func GetSlo(clientProvider *client.Provider, logger *zap.Logger) tools.MCPTool {
 				mcp.Required(),
 			),
 		),
-		Handler: func(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 			slug, err := params.String(request, "slug", true, "")
 			if err != nil {
 				return nil, err
 			}
 
 			queryParams := &s_l_o.ReadSLOParams{
-				Slug: slug,
+				Context: ctx,
 
-				Context: session.Context,
+				Slug: slug,
 			}
 
-			api, err := clientProvider.ConfigV1Client(session)
+			api, err := clientProvider.ConfigV1Client()
 			if err != nil {
 				return nil, err
 			}
@@ -79,7 +80,7 @@ func ListSlos(clientProvider *client.Provider, logger *zap.Logger) tools.MCPTool
 				mcp.Description("Filters results by slug, where any SLO with a matching slug in the given list (and matches all other filters) is returned."),
 			),
 		),
-		Handler: func(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 			collectionSlugs, err := params.StringArray(request, "collection_slugs", false, nil)
 			if err != nil {
 				return nil, err
@@ -111,6 +112,8 @@ func ListSlos(clientProvider *client.Provider, logger *zap.Logger) tools.MCPTool
 			}
 
 			queryParams := &s_l_o.ListSLOsParams{
+				Context: ctx,
+
 				CollectionSlugs: collectionSlugs,
 
 				Names: names,
@@ -122,11 +125,9 @@ func ListSlos(clientProvider *client.Provider, logger *zap.Logger) tools.MCPTool
 				ServiceSlugs: serviceSlugs,
 
 				Slugs: slugs,
-
-				Context: session.Context,
 			}
 
-			api, err := clientProvider.ConfigV1Client(session)
+			api, err := clientProvider.ConfigV1Client()
 			if err != nil {
 				return nil, err
 			}

--- a/mcp-server/pkg/mcpserver/mcpserver.go
+++ b/mcp-server/pkg/mcpserver/mcpserver.go
@@ -122,13 +122,7 @@ func (t *loggingTool) handle(ctx context.Context, request mcp.CallToolRequest) (
 }
 
 func (t *loggingTool) mustHandle(ctx context.Context, request mcp.CallToolRequest) *mcp.CallToolResult {
-	sessionAPIToken := authcontext.FetchSessionAPIToken(ctx)
-
-	session := tools.Session{
-		APIToken: sessionAPIToken,
-		Context:  ctx,
-	}
-	resp, err := t.tool.Handler(session, request)
+	resp, err := t.tool.Handler(ctx, request)
 	if err != nil {
 		t.logger.Info("received error from handler",
 			zap.String("method", request.Method),

--- a/mcp-server/pkg/mcpserver/mcpserver_test.go
+++ b/mcp-server/pkg/mcpserver/mcpserver_test.go
@@ -26,7 +26,7 @@ func TestLoggingTool_mustHandle(t *testing.T) {
 			name:            "successful JSON response",
 			sessionAPIToken: "test-token",
 			tool: tools.MCPTool{
-				Handler: func(_ tools.Session, _ mcp.CallToolRequest) (*tools.Result, error) {
+				Handler: func(_ context.Context, _ mcp.CallToolRequest) (*tools.Result, error) {
 					return &tools.Result{
 						JSONContent: map[string]string{"key": "value"},
 					}, nil
@@ -40,7 +40,7 @@ func TestLoggingTool_mustHandle(t *testing.T) {
 			name:            "handler error",
 			sessionAPIToken: "test-token",
 			tool: tools.MCPTool{
-				Handler: func(_ tools.Session, _ mcp.CallToolRequest) (*tools.Result, error) {
+				Handler: func(_ context.Context, _ mcp.CallToolRequest) (*tools.Result, error) {
 					return &tools.Result{}, fmt.Errorf("handler error")
 				},
 			},
@@ -50,7 +50,7 @@ func TestLoggingTool_mustHandle(t *testing.T) {
 			name:            "response with Chronosphere link",
 			sessionAPIToken: "test-token",
 			tool: tools.MCPTool{
-				Handler: func(_ tools.Session, _ mcp.CallToolRequest) (*tools.Result, error) {
+				Handler: func(_ context.Context, _ mcp.CallToolRequest) (*tools.Result, error) {
 					return &tools.Result{
 						ChronosphereLink: "https://chronosphere.io",
 						JSONContent:      map[string]string{"data": "test"},
@@ -66,7 +66,7 @@ func TestLoggingTool_mustHandle(t *testing.T) {
 			name:            "response with image content",
 			sessionAPIToken: "test-token",
 			tool: tools.MCPTool{
-				Handler: func(_ tools.Session, _ mcp.CallToolRequest) (*tools.Result, error) {
+				Handler: func(_ context.Context, _ mcp.CallToolRequest) (*tools.Result, error) {
 					return &tools.Result{
 						ImageContent: []byte("test-image-data"),
 					}, nil
@@ -80,7 +80,7 @@ func TestLoggingTool_mustHandle(t *testing.T) {
 			name:            "response with metadata",
 			sessionAPIToken: "test-token",
 			tool: tools.MCPTool{
-				Handler: func(_ tools.Session, _ mcp.CallToolRequest) (*tools.Result, error) {
+				Handler: func(_ context.Context, _ mcp.CallToolRequest) (*tools.Result, error) {
 					return &tools.Result{
 						JSONContent: map[string]string{"key": "value"},
 						Meta:        map[string]any{"meta-key": "meta-value"},

--- a/mcp-server/pkg/tools/events/events.go
+++ b/mcp-server/pkg/tools/events/events.go
@@ -2,6 +2,7 @@
 package events
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/chronosphereio/mcp-server/pkg/ptr"
@@ -44,7 +45,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 					mcp.Description("The query to filter events e.g. categories, types, sources and arbitrary labels.")),
 				params.WithTimeRange(),
 			),
-			Handler: func(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+			Handler: func(_ context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 				timeRange, err := params.ParseTimeRange(request)
 				if err != nil {
 					return nil, err
@@ -62,7 +63,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 					queryParams.Query = ptr.To(query)
 				}
 
-				api, err := t.clientProvider.DataUnstableClient(session)
+				api, err := t.clientProvider.DataUnstableClient()
 				if err != nil {
 					return nil, err
 				}
@@ -79,13 +80,13 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 			Metadata: tools.NewMetadata("get_events_metadata",
 				mcp.WithDescription("List properties you can query on events"),
 			),
-			Handler: func(session tools.Session, _ mcp.CallToolRequest) (*tools.Result, error) {
-				api, err := t.clientProvider.DataUnstableClient(session)
+			Handler: func(ctx context.Context, _ mcp.CallToolRequest) (*tools.Result, error) {
+				api, err := t.clientProvider.DataUnstableClient()
 				if err != nil {
 					return nil, err
 				}
 				resp, err := api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
-					Context: session.Context,
+					Context: ctx,
 					Field:   ptr.To(string(models.DataunstableEventFieldCATEGORYEVENTFIELD)),
 				})
 
@@ -103,7 +104,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				eventsMetadata.Categories = resp.Payload.Values
 
 				resp, err = api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
-					Context: session.Context,
+					Context: ctx,
 					Field:   ptr.To(string(models.DataunstableEventFieldSOURCEEVENTFIELD)),
 				})
 				if err != nil {
@@ -113,7 +114,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				eventsMetadata.Sources = resp.Payload.Values
 
 				resp, err = api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
-					Context: session.Context,
+					Context: ctx,
 					Field:   ptr.To(string(models.DataunstableEventFieldTYPEEVENTFIELD)),
 				})
 				if err != nil {
@@ -123,7 +124,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				eventsMetadata.Types = resp.Payload.Values
 
 				resp, err = api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
-					Context: session.Context,
+					Context: ctx,
 					Field:   ptr.To(string(models.DataunstableEventFieldLABELNAMEEVENTFIELD)),
 				})
 				if err != nil {
@@ -133,7 +134,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				eventsMetadata.LabelNames = resp.Payload.Values
 
 				resp, err = api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
-					Context: session.Context,
+					Context: ctx,
 					Field:   ptr.To(string(models.DataunstableEventFieldLABELNAMEEVENTFIELD)),
 				})
 				if err != nil {
@@ -143,7 +144,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				eventsMetadata.LabelNames = resp.Payload.Values
 
 				resp, err = api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
-					Context: session.Context,
+					Context: ctx,
 					Field:   ptr.To(string(models.DataunstableEventFieldLENSSERVICEEVENTFIELD)),
 				})
 				if err != nil {
@@ -163,18 +164,18 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 					mcp.Required(),
 				),
 			),
-			Handler: func(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 				labelName, err := params.String(request, "label_name", true, "")
 				if err != nil {
 					return nil, err
 				}
 
-				api, err := t.clientProvider.DataUnstableClient(session)
+				api, err := t.clientProvider.DataUnstableClient()
 				if err != nil {
 					return nil, err
 				}
 				resp, err := api.DataUnstable.ListEventFieldValues(&data_unstable.ListEventFieldValuesParams{
-					Context:   session.Context,
+					Context:   ctx,
 					LabelName: ptr.To(labelName),
 					Field:     ptr.To(string(models.DataunstableEventFieldLABELNAMEEVENTFIELD)),
 				})

--- a/mcp-server/pkg/tools/monitors/monitors.go
+++ b/mcp-server/pkg/tools/monitors/monitors.go
@@ -2,6 +2,7 @@
 package monitors
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/chronosphereio/mcp-server/pkg/ptr"
@@ -62,7 +63,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 					mcp.Enum("SORT_BY_STATE"),
 				),
 			),
-			Handler: func(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 				// Parse parameters
 				monitorSlugs, err := params.StringArray(request, "monitor_slugs", false, nil)
 				if err != nil {
@@ -96,7 +97,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 
 				// Construct query parameters
 				queryParams := state_unstable.NewListMonitorStatusesParams().
-					WithContext(session.Context)
+					WithContext(ctx)
 
 				if len(monitorSlugs) > 0 {
 					queryParams.SetMonitorSlugs(monitorSlugs)
@@ -128,7 +129,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				t.logger.Info("list monitor statuses", zap.Any("params", queryParams))
 
 				// Get client and make API call
-				stateAPI, err := t.clientProvider.StateUnstableClient(session)
+				stateAPI, err := t.clientProvider.StateUnstableClient()
 				if err != nil {
 					return nil, err
 				}

--- a/mcp-server/pkg/tools/prometheus/prometheus.go
+++ b/mcp-server/pkg/tools/prometheus/prometheus.go
@@ -3,6 +3,7 @@ package prometheus
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"time"
 
@@ -13,7 +14,7 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-func (t *Tools) listPrometheusSeries(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+func (t *Tools) listPrometheusSeries(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 	selectors, errResult := params.StringArray(request, "selectors", true, nil)
 	if errResult != nil {
 		return nil, errResult
@@ -28,11 +29,11 @@ func (t *Tools) listPrometheusSeries(session tools.Session, request mcp.CallTool
 		return nil, err
 	}
 
-	api, err := t.renderer.DataAPI(session)
+	api, err := t.renderer.DataAPI()
 	if err != nil {
 		return nil, err
 	}
-	resp, warnings, err := api.Series(session.Context, selectors, timeRange.Start, timeRange.End)
+	resp, warnings, err := api.Series(ctx, selectors, timeRange.Start, timeRange.End)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get series: %s", err)
 	}
@@ -40,7 +41,7 @@ func (t *Tools) listPrometheusSeries(session tools.Session, request mcp.CallTool
 	return promJSONResponse(resp, warnings)
 }
 
-func (t *Tools) queryPrometheusRange(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+func (t *Tools) queryPrometheusRange(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 	query, err := params.String(request, "query", true, "")
 	if err != nil {
 		return nil, err
@@ -60,11 +61,11 @@ func (t *Tools) queryPrometheusRange(session tools.Session, request mcp.CallTool
 		return nil, fmt.Errorf("stepSeconds must be a positive integer")
 	}
 
-	api, err := t.renderer.DataAPI(session)
+	api, err := t.renderer.DataAPI()
 	if err != nil {
 		return nil, err
 	}
-	resp, warnings, err := api.QueryRange(session.Context, query, v1.Range{
+	resp, warnings, err := api.QueryRange(ctx, query, v1.Range{
 		Start: timeRange.Start,
 		End:   timeRange.End,
 		Step:  step,
@@ -80,7 +81,7 @@ func (t *Tools) queryPrometheusRange(session tools.Session, request mcp.CallTool
 	return promJSONResponse(matrix, warnings)
 }
 
-func (t *Tools) renderPrometheusRangeQuery(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+func (t *Tools) renderPrometheusRangeQuery(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 	query, err := params.String(request, "query", true, "")
 	if err != nil {
 		return nil, err
@@ -95,11 +96,11 @@ func (t *Tools) renderPrometheusRangeQuery(session tools.Session, request mcp.Ca
 		return nil, err
 	}
 
-	api, err := t.renderer.DataAPI(session)
+	api, err := t.renderer.DataAPI()
 	if err != nil {
 		return nil, err
 	}
-	resp, _, err := api.QueryRange(session.Context, query, v1.Range{
+	resp, _, err := api.QueryRange(ctx, query, v1.Range{
 		Start: timeRange.Start,
 		End:   timeRange.End,
 		Step:  time.Duration(step) * time.Second,
@@ -133,7 +134,7 @@ func (t *Tools) renderPrometheusPNG(
 	return buf.Bytes(), nil
 }
 
-func (t *Tools) queryPrometheusInstant(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+func (t *Tools) queryPrometheusInstant(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 	expression, errResult := params.String(request, "expression", true, "")
 	if errResult != nil {
 		return nil, errResult
@@ -142,11 +143,11 @@ func (t *Tools) queryPrometheusInstant(session tools.Session, request mcp.CallTo
 	if errResult != nil {
 		return nil, errResult
 	}
-	api, err := t.renderer.DataAPI(session)
+	api, err := t.renderer.DataAPI()
 	if err != nil {
 		return nil, err
 	}
-	resp, warnings, err := api.Query(session.Context, expression, evalTime)
+	resp, warnings, err := api.Query(ctx, expression, evalTime)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query prometheus: %s", err)
 	}
@@ -154,7 +155,7 @@ func (t *Tools) queryPrometheusInstant(session tools.Session, request mcp.CallTo
 	return promJSONResponse(resp, warnings)
 }
 
-func (t *Tools) listPrometheusLabelValues(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+func (t *Tools) listPrometheusLabelValues(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 	labelName, errResult := params.String(request, "label_name", true, "")
 	if errResult != nil {
 		return nil, errResult
@@ -167,11 +168,11 @@ func (t *Tools) listPrometheusLabelValues(session tools.Session, request mcp.Cal
 	if err != nil {
 		return nil, err
 	}
-	api, err := t.renderer.DataAPI(session)
+	api, err := t.renderer.DataAPI()
 	if err != nil {
 		return nil, err
 	}
-	resp, warnings, err := api.LabelValues(session.Context, labelName, selectors, timeRange.Start, timeRange.End)
+	resp, warnings, err := api.LabelValues(ctx, labelName, selectors, timeRange.Start, timeRange.End)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get label names: %s", err)
 	}
@@ -179,7 +180,7 @@ func (t *Tools) listPrometheusLabelValues(session tools.Session, request mcp.Cal
 	return promJSONResponse(resp, warnings)
 }
 
-func (t *Tools) listPrometheusLabelNames(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+func (t *Tools) listPrometheusLabelNames(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 	selectors, errResult := params.StringArray(request, "selectors", false, nil)
 	if errResult != nil {
 		return nil, errResult
@@ -190,28 +191,28 @@ func (t *Tools) listPrometheusLabelNames(session tools.Session, request mcp.Call
 		return nil, err
 	}
 
-	api, err := t.renderer.DataAPI(session)
+	api, err := t.renderer.DataAPI()
 	if err != nil {
 		return nil, err
 	}
 	// TODO: should we set a limit?
-	resp, warnings, err := api.LabelNames(session.Context, selectors, timeRange.End, timeRange.End)
+	resp, warnings, err := api.LabelNames(ctx, selectors, timeRange.End, timeRange.End)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get label names: %s", err)
 	}
 	return promJSONResponse(resp, warnings)
 }
 
-func (t *Tools) listPrometheusSeriesMetadata(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+func (t *Tools) listPrometheusSeriesMetadata(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 	metric, err := params.String(request, "metric", true, "")
 	if err != nil {
 		return nil, err
 	}
-	api, err := t.renderer.DataAPI(session)
+	api, err := t.renderer.DataAPI()
 	if err != nil {
 		return nil, err
 	}
-	resp, err := api.Metadata(session.Context, metric, "1")
+	resp, err := api.Metadata(ctx, metric, "1")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get series metadata: %s", err)
 	}

--- a/mcp-server/pkg/tools/tools.go
+++ b/mcp-server/pkg/tools/tools.go
@@ -19,7 +19,7 @@ type Result struct {
 	ChronosphereLink string
 }
 
-type Handler func(session Session, request mcp.CallToolRequest) (*Result, error)
+type Handler func(ctx context.Context, request mcp.CallToolRequest) (*Result, error)
 
 type Metadata struct {
 	// The name of the tool.
@@ -35,8 +35,7 @@ type Metadata struct {
 }
 
 type Session struct {
-	APIToken string
-	Context  context.Context
+	Context context.Context
 }
 
 type MCPTool struct {

--- a/mcp-server/pkg/tools/traces/traces.go
+++ b/mcp-server/pkg/tools/traces/traces.go
@@ -2,6 +2,7 @@
 package traces
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/chronosphereio/mcp-server/pkg/ptr"
@@ -51,7 +52,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				),
 				params.WithTimeRange(),
 			),
-			Handler: func(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
 				timeRange, err := params.ParseTimeRange(request)
 				if err != nil {
 					return nil, err
@@ -75,7 +76,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 				}
 
 				queryParams := &data_unstable.ListTracesParams{
-					Context:   session.Context,
+					Context:   ctx,
 					StartTime: (*strfmt.DateTime)(ptr.To(timeRange.Start)),
 					EndTime:   (*strfmt.DateTime)(ptr.To(timeRange.End)),
 				}
@@ -94,7 +95,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 					queryParams.Operation = &operation
 				}
 
-				api, err := t.clientProvider.DataUnstableClient(session)
+				api, err := t.clientProvider.DataUnstableClient()
 				if err != nil {
 					return nil, err
 				}

--- a/tools/cmd/mcpgen/tmpl/entity_tool.go.tmpl
+++ b/tools/cmd/mcpgen/tmpl/entity_tool.go.tmpl
@@ -1,6 +1,7 @@
 package {{ .PkgName }}
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -29,7 +30,7 @@ func {{ $toolSpec.CamelName }}(clientProvider *client.Provider, logger *zap.Logg
                 ),
             {{ end }}
         ),
-        Handler: func(session tools.Session, request mcp.CallToolRequest) (*tools.Result, error) {
+        Handler: func(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
         {{ range $idx, $param := $toolSpec.Parameters }}
             {{ $param.GoName }}, err := params.{{$param.ParseType}}(request, {{ printf "%q" $param.Name }}, {{ if $param.Required }}true{{ else }}false{{ end }}, {{ $param.DefaultValue }})
             if err != nil {
@@ -38,6 +39,7 @@ func {{ $toolSpec.CamelName }}(clientProvider *client.Provider, logger *zap.Logg
         {{ end }}
 
             queryParams := &{{$entity.PkgName}}.{{$toolSpec.APIParam}}Params{
+                Context: ctx,
             {{ range $idx, $param := $toolSpec.Parameters }}
                 {{ if eq $param.GoName "pageToken" -}}
                     {{$param.SwaggerGoFieldName}}: &{{$param.GoName}},
@@ -49,10 +51,9 @@ func {{ $toolSpec.CamelName }}(clientProvider *client.Provider, logger *zap.Logg
                     {{$param.SwaggerGoFieldName}}: {{$param.GoName -}},
                 {{end -}}
             {{ end }}
-                Context: session.Context,
             }
 
-			api, err := clientProvider.ConfigV1Client(session)
+			api, err := clientProvider.ConfigV1Client()
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
we no longer need a "session" object since all auth header forwarding is
now done by round tripper middleware.