### PR TITLE
remove private prom API client

### DIFF
--- a/mcp-server/pkg/client/provider.go
+++ b/mcp-server/pkg/client/provider.go
@@ -45,11 +45,6 @@ func (c *Provider) PrometheusDataClient() (api.Client, error) {
 	return c.prometheusClientForBasePath("/data/metrics")
 }
 
-// PrometheusPromClient creates a new client to hit Prometheus APIs.
-func (c *Provider) PrometheusPromClient() (api.Client, error) {
-	return c.prometheusClientForBasePath("/app/prom")
-}
-
 // DataUnstableClient creates a new client to hit data unstable APIs.
 func (c *Provider) DataUnstableClient() (*dataunstable.DataUnstableAPI, error) {
 	t, err := c.transportForSession("/")

--- a/mcp-server/pkg/tools/prometheus/renderer.go
+++ b/mcp-server/pkg/tools/prometheus/renderer.go
@@ -21,7 +21,6 @@ import (
 
 type Renderer struct {
 	DataAPI func() (v1.API, error)
-	PromAPI func() (v1.API, error)
 }
 
 // RendererOptions contains options for the Renderer.
@@ -35,13 +34,6 @@ func NewRenderer(
 	return &Renderer{
 		DataAPI: func() (v1.API, error) {
 			c, err := opts.ClientProvider.PrometheusDataClient()
-			if err != nil {
-				return nil, err
-			}
-			return v1.NewAPI(c), nil
-		},
-		PromAPI: func() (v1.API, error) {
-			c, err := opts.ClientProvider.PrometheusPromClient()
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
We only use the prometheus data API. The non-data APIs allow for direct
prom API access which we consider private.