### PR TITLE
move run-chronomcp make target to a script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,12 +55,7 @@ chronomcp:
 	go build $(LDFLAGS) -o $(server_bin_path) ./mcp-server
 
 run-chronomcp: chronomcp
-	if [ ! -f $(CONFIG_FILE) ]; then \
-		echo "Config file $(CONFIG_FILE) not found"; \
-		exit 1; \
-	fi
-	@echo "Starting MCP server..."
-	$(server_bin_path) -c $(CONFIG_FILE) --org-name $(CHRONOSPHERE_ORG_NAME) --api-token-filename .chronosphere_api_token --verbose
+	CONFIG_FILE=$(CONFIG_FILE) ./scripts/run-chronomcp.sh $(server_bin_path)
 
 build-server: chronomcp # alias for backwards compatibility
 

--- a/scripts/run-chronomcp.sh
+++ b/scripts/run-chronomcp.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eoux pipefail
+
+binary=$1
+
+if [ ! -f "${CONFIG_FILE}" ]; then
+  echo "Config file ${CONFIG_FILE} not found";
+  exit 1;
+fi
+
+if [ -z "${CHRONOSPHERE_ORG_NAME:-}" ]; then
+  echo "Environment variable CHRONOSPHERE_ORG_NAME is not set";
+  exit 1;
+fi
+
+echo "Starting MCP server..."
+ARGS=()
+if [ -z "${CHRONOSPHERE_API_TOKEN:-}" ]; then
+  if [ ! -f .chronosphere_api_token ]; then
+    echo "Either CHRONOSPHERE_API_TOKEN needs to be set or .chronosphere_api_token file must contain the chronosphere api token";
+    exit 1;
+  fi
+  ARGS=(--api-token-filename .chronosphere_api_token);
+fi
+
+${binary} -c "${CONFIG_FILE}" "${ARGS[@]}" --verbose


### PR DESCRIPTION
Adding more validation to run-chronomcp and moving it to a separate
script to avoid hard to read make file escapes for bash.