### PR TITLE
move flags to the mcserverfx package

### DIFF
--- a/mcp-server/pkg/cmd/root.go
+++ b/mcp-server/pkg/cmd/root.go
@@ -19,7 +19,7 @@ import (
 
 // New returns the root command.
 func New() *cobra.Command {
-	flags := &Flags{}
+	flags := &mcpserverfx.Flags{}
 	cmd := &cobra.Command{
 		Use:   "chronomcp",
 		Short: "chronomcp provides an MCP server to AI applications",

--- a/mcp-server/pkg/mcpserverfx/flags.go
+++ b/mcp-server/pkg/mcpserverfx/flags.go
@@ -1,4 +1,4 @@
-package cmd
+package mcpserverfx
 
 import (
 	"errors"


### PR DESCRIPTION
Moving flags to the server package closer to server config parsing to
make it easier to merge configs and flags.

We have two sources of configuration: a config file and command line
flags. Commandline flags make it easier to run the server quickly for
local set ups, while the yaml configuration file is easier to use when
the server is deployed as a service.

This adds a lot of complexity when initializing the server to build the
right options structs and validating the configuration.

I'm planning to move configuration loading to be yaml driven while
having the ability to override configs using commandline flags.