### PR TITLE
consolidate cmd flags and config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,8 @@ make chronomcp
 This MCP server uses the same authentication methods as chronoctl. By default, the Makefile expects the API token to be stored in `.chronosphere_api_token`.
 
 #### Run the mcp server
-Create a `.chronosphere_api_token` file in the root of the repo with your Chronosphere API token.
 ```sh
-make run-chronomcp CHRONOSPHERE_ORG_NAME=<your org here>
+make run-chronomcp CHRONOSPHERE_ORG_NAME=<your org here> CHRONOSPHERE_API_TOKEN=<your api token here>
 ```
 
 ### Debugging MCP Tools

--- a/config.http.yaml
+++ b/config.http.yaml
@@ -14,3 +14,16 @@ server:
   tools:
     # List of tools to disable if you don't want to serve them to the client/host.
     disabled: []
+
+  chronosphere:
+    apiURL: ${CHRONOSPHERE_ORG_NAME:""}.chronosphere.io
+    # The API token for Chronosphere, used to authenticate requests.
+    # Leave empty if forwarding bearer token.
+    apiToken: ${CHRONOSPHERE_API_TOKEN:""}
+    # Whether the organization uses LogScale for logs.
+    # Must set logscaleURL and logscaleAPIToken if true.
+    useLogscale: ${USE_LOGSCALE:false}
+    # The URL for the logscale API if using LogScale for logs.
+    logscaleURL: ${CHRONOSPHERE_ORG_NAME:""}.logs.chronosphere.io
+    # The API token for LogScale if using LogScale for logs.
+    logscaleAPIToken: ${LOGSCALE_API_TOKEN:""}

--- a/config.sse.yaml
+++ b/config.sse.yaml
@@ -14,3 +14,16 @@ server:
   tools:
     # List of tools to disable if you don't want to serve them to the client/host.
     disabled: []
+
+  chronosphere:
+    apiURL: ${CHRONOSPHERE_ORG_NAME:""}.chronosphere.io
+    # The API token for Chronosphere, used to authenticate requests.
+    # Leave empty if forwarding bearer token.
+    apiToken: ${CHRONOSPHERE_API_TOKEN:""}
+    # Whether the organization uses LogScale for logs.
+    # Must set logscaleURL and logscaleAPIToken if true.
+    useLogscale: ${USE_LOGSCALE:false}
+    # The URL for the logscale API if using LogScale for logs.
+    logscaleURL: ${CHRONOSPHERE_ORG_NAME:""}.logs.chronosphere.io
+    # The API token for LogScale if using LogScale for logs.
+    logscaleAPIToken: ${LOGSCALE_API_TOKEN:""}

--- a/config.yaml
+++ b/config.yaml
@@ -14,3 +14,16 @@ server:
   tools:
     # List of tools to disable if you don't want to serve them to the client/host.
     disabled: []
+
+  chronosphere:
+    apiURL: ${CHRONOSPHERE_ORG_NAME:""}.chronosphere.io
+    # The API token for Chronosphere, used to authenticate requests.
+    # Leave empty if forwarding bearer token.
+    apiToken: ${CHRONOSPHERE_API_TOKEN:""}
+    # Whether the organization uses LogScale for logs.
+    # Must set logscaleURL and logscaleAPIToken if true.
+    useLogscale: ${USE_LOGSCALE:false}
+    # The URL for the logscale API if using LogScale for logs.
+    logscaleURL: ${CHRONOSPHERE_ORG_NAME:""}.logs.chronosphere.io
+    # The API token for LogScale if using LogScale for logs.
+    logscaleAPIToken: ${LOGSCALE_API_TOKEN:""}

--- a/mcp-server/pkg/cmd/root.go
+++ b/mcp-server/pkg/cmd/root.go
@@ -34,32 +34,10 @@ func New() *cobra.Command {
 				fx.Provide(func() (config.Provider, error) {
 					return pkgconfig.ParseFile(flags.ConfigFilePath)
 				}),
-				fx.Provide(func() (*clientfx.APIConfig, error) {
-					apiURL, err := flags.GetAPIURL()
-					if err != nil {
-						return nil, err
-					}
-					apiToken, err := flags.GetAPIToken()
-					if err != nil {
-						return nil, err
-					}
-					logcaleToken, err := flags.GetLogscaleAPIToken()
-					if err != nil {
-						return nil, err
-					}
-					logscaleURL, err := flags.GetLogscaleURL()
-					if err != nil {
-						return nil, err
-					}
-					return &clientfx.APIConfig{
-						APIURL:           apiURL,
-						APIToken:         apiToken,
-						LogscaleURL:      logscaleURL,
-						LogscaleAPIToken: logcaleToken,
-						UseLogscale:      flags.UseLogScale,
-					}, nil
+				fx.Provide(func() *mcpserverfx.Flags {
+					return flags
 				}),
-				fx.Provide(func(apiConfig *clientfx.APIConfig) *links.Builder {
+				fx.Provide(func(apiConfig *clientfx.ChronosphereConfig) *links.Builder {
 					return links.NewBuilder(apiConfig.APIURL)
 				}),
 				clientfx.Module,

--- a/mcp-server/pkg/mcpserverfx/config.go
+++ b/mcp-server/pkg/mcpserverfx/config.go
@@ -5,19 +5,59 @@ import (
 	"fmt"
 
 	"go.uber.org/config"
+	"go.uber.org/fx"
 	"gopkg.in/validator.v2"
+
+	"github.com/chronosphereio/chronosphere-mcp/mcp-server/pkg/clientfx"
 )
 
-func parseConfig(cfgProvider config.Provider) (*Config, error) {
+const (
+	apiURLFormat      = "https://%s.chronosphere.io"
+	logscaleURLFormat = "https://%s.logs.chronosphere.io"
+)
+
+type configResult struct {
+	fx.Out
+
+	Config       *Config
+	Chronosphere *clientfx.ChronosphereConfig
+}
+
+func parseConfig(cfgProvider config.Provider, flags *Flags) (configResult, error) {
 	var cfg Config
 	if err := cfgProvider.Get(configKey).Populate(&cfg); err != nil {
-		return nil, fmt.Errorf("failed to populate config: %v", err)
+		return configResult{}, fmt.Errorf("failed to populate config: %w", err)
 	}
+
+	mergeConfig(&cfg, flags)
+
 	if err := validator.Validate(cfg); err != nil {
-		return nil, fmt.Errorf("failed to validate config: %v", err)
+		return configResult{}, fmt.Errorf("failed to validate config: %w", err)
 	}
-	if err := validator.Validate(cfg); err != nil {
-		return nil, err
+
+	if err := cfg.Validate(); err != nil {
+		return configResult{}, fmt.Errorf("failed to validate Chronosphere config: %w", err)
 	}
-	return &cfg, nil
+
+	return configResult{
+		Config:       &cfg,
+		Chronosphere: &cfg.Chronosphere,
+	}, nil
+}
+
+func mergeConfig(c *Config, f *Flags) {
+	if f.UseLogScale {
+		c.Chronosphere.UseLogscale = f.UseLogScale
+	}
+
+	if f.orgName != "" {
+		c.Chronosphere.APIURL = fmt.Sprintf(apiURLFormat, f.orgName)
+		c.Chronosphere.LogscaleURL = fmt.Sprintf(logscaleURLFormat, f.orgName)
+	}
+	if f.apiToken != "" {
+		c.Chronosphere.APIToken = f.apiToken
+	}
+	if f.UseLogScale {
+		c.Chronosphere.UseLogscale = f.UseLogScale
+	}
 }

--- a/mcp-server/pkg/mcpserverfx/flags.go
+++ b/mcp-server/pkg/mcpserverfx/flags.go
@@ -1,102 +1,22 @@
 package mcpserverfx
 
 import (
-	"errors"
-	"fmt"
-	"os"
-	"strings"
-
 	"github.com/spf13/cobra"
 )
 
-const (
-	// ChronosphereOrgNameKey is the environment variable that specifies the Chronosphere customer organization
-	ChronosphereOrgNameKey = "CHRONOSPHERE_ORG_NAME"
-	// ChronosphereAPITokenKey is the environment variable that specifies the Chronosphere API token
-	ChronosphereAPITokenKey = "CHRONOSPHERE_API_TOKEN"
-	// LogscaleAPITokenKey is the environment variable that specifies the LogScale API token
-	LogscaleAPITokenKey = "LOGSCALE_API_TOKEN"
-	apiURLFormat        = "https://%s.chronosphere.io"
-	logscaleURLFormat   = "https://%s.logs.chronosphere.io"
-)
-
 type Flags struct {
-	apiToken         string
-	apiTokenFileName string
-	orgName          string
-	apiURL           string
-	ConfigFilePath   string
-	VerboseLogging   bool
-	UseLogScale      bool
+	apiToken       string
+	orgName        string
+	ConfigFilePath string
+	VerboseLogging bool
+	UseLogScale    bool
 }
 
 // AddFlags adds client flags to a Cobra command.
 func (f *Flags) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.ConfigFilePath, "config-file", "c", "", "The YAML file containing configuration parameters")
 	cmd.Flags().BoolVarP(&f.VerboseLogging, "verbose", "v", false, "Whether verbose logging, including logging requests and responses, should be enabled")
-	cmd.Flags().StringVar(&f.apiToken, "api-token", "", "The client API token used to authenticate to user. Mutally exclusive with --api-token-filename. If both --api-token and --api-token-filename are unset, the "+ChronosphereAPITokenKey+" environment variable is used.")
-	cmd.Flags().StringVar(&f.apiTokenFileName, "api-token-filename", "", "A file containing the API token used for authentication. Mutally exclusive with --api-token. If both --api-token and --api-token-filename are unset, the "+ChronosphereAPITokenKey+" environment variable is used.")
-	cmd.Flags().StringVar(&f.orgName, "org-name", "", "The name of your team's Chronosphere organization. Defaults to "+ChronosphereOrgNameKey+" environment variable.")
+	cmd.Flags().StringVar(&f.apiToken, "api-token", "", "The client API token used to authenticate to user.")
+	cmd.Flags().StringVar(&f.orgName, "org-name", "", "The name of your team's Chronosphere organization.")
 	cmd.Flags().BoolVar(&f.UseLogScale, "use-logscale", false, "Whether to use LogScale instead of chronosphere logs for log queries. If set, the LogScale API token must be provided via the LOGSCALE_API_TOKEN environment variable.")
-
-	cmd.Flags().StringVar(&f.apiURL, "api-url", f.apiURL, "The URL of the Chronosphere API. Defaults to https://<organization>.chronosphere.io/api.")
-	cmd.Flags().MarkHidden("api-url") //nolint:errcheck
-}
-
-func (f *Flags) GetLogscaleAPIToken() (string, error) {
-	if f.UseLogScale {
-		if token := os.Getenv(LogscaleAPITokenKey); token != "" {
-			return token, nil
-		}
-		return "", errors.New("LogScale API token must be provided via the " + LogscaleAPITokenKey + " environment variable")
-	}
-	return "", nil
-}
-
-func (f *Flags) GetAPIToken() (string, error) {
-	if f.apiToken != "" && f.apiTokenFileName != "" {
-		return "", errors.New("only one of --api-token and --api-token-filename can be set")
-	}
-
-	if f.apiToken != "" {
-		return f.apiToken, nil
-	}
-
-	if f.apiTokenFileName != "" {
-		b, err := os.ReadFile(f.apiTokenFileName)
-		if err != nil {
-			return "", fmt.Errorf("reading api token from file %s: %w", f.apiTokenFileName, err)
-		}
-		return strings.TrimSpace(string(b)), nil
-	}
-
-	if key := os.Getenv(ChronosphereAPITokenKey); key != "" {
-		return key, nil
-	}
-
-	return "", errors.New("api token must be provided as a flag, via the " + ChronosphereAPITokenKey + " environment variable, or by setting a file with the --api-token-filename flag")
-}
-
-func (f *Flags) GetAPIURL() (string, error) {
-	if f.apiURL != "" {
-		return f.apiURL, nil
-	}
-	if f.orgName == "" {
-		if f.orgName = os.Getenv(ChronosphereOrgNameKey); f.orgName == "" {
-			return "", errors.New("org name must be provided as a flag or via the " + ChronosphereOrgNameKey + " environment variable")
-		}
-	}
-	return fmt.Sprintf(apiURLFormat, f.orgName), nil
-}
-
-func (f *Flags) GetLogscaleURL() (string, error) {
-	if f.UseLogScale {
-		if f.orgName == "" {
-			if f.orgName = os.Getenv(ChronosphereOrgNameKey); f.orgName == "" {
-				return "", errors.New("org name must be provided as a flag or via the " + ChronosphereOrgNameKey + " environment variable")
-			}
-		}
-		return fmt.Sprintf(logscaleURLFormat, f.orgName), nil
-	}
-	return "", nil
 }

--- a/mcp-server/pkg/toolsfx/schema_validation_test.go
+++ b/mcp-server/pkg/toolsfx/schema_validation_test.go
@@ -28,8 +28,8 @@ func getAllTools(t *testing.T) []tools.MCPTool {
 			return zap.NewNop()
 		}),
 		// Provide test API config (with empty values for testing)
-		fx.Provide(func() *clientfx.APIConfig {
-			return &clientfx.APIConfig{
+		fx.Provide(func() *clientfx.ChronosphereConfig {
+			return &clientfx.ChronosphereConfig{
 				APIURL:      "https://test.chronosphere.io",
 				APIToken:    "test-token",
 				LogscaleURL: "https://test.logs.chronosphere.io",

--- a/scripts/run-chronomcp.sh
+++ b/scripts/run-chronomcp.sh
@@ -15,13 +15,4 @@ if [ -z "${CHRONOSPHERE_ORG_NAME:-}" ]; then
 fi
 
 echo "Starting MCP server..."
-ARGS=""
-if [ -z "${CHRONOSPHERE_API_TOKEN:-}" ]; then
-  if [ ! -f .chronosphere_api_token ]; then
-    echo "Either CHRONOSPHERE_API_TOKEN needs to be set or .chronosphere_api_token file must contain the chronosphere api token";
-    exit 1;
-  fi
-  ARGS=(--api-token-filename .chronosphere_api_token);
-fi
-
-${binary} -c "${CONFIG_FILE}" "${ARGS[@]}" --verbose
+${binary} -c "${CONFIG_FILE}" --verbose


### PR DESCRIPTION
Move configuration to yaml files with optional commandline arguments
that can override the yaml file values so command line flags are
completely optional when configs are set in confg.yaml.

Removed the `--api-token-filename` option as we already have 3 other
ways to provide the token (config, env var, cmd flag).

Removed the `--api-url` option since it can now be set in the config
file.