### PR TITLE
use config.http.yaml by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ tools_bin_path            := $(abspath ./_tools/bin)
 server_bin_path           := $(abspath ./bin/chronomcp)
 agent_bin_path           := $(abspath ./bin/agent)
 
-CONFIG_FILE ?= config.yaml
+CONFIG_FILE ?= config.http.yaml
 AGENT_CONFIG_FILE ?= agent.yaml
 ENV_FILE ?= .env
 LIBRECHAT_CONFIG ?= librechat.yaml


### PR DESCRIPTION
The stdio output isn't Makefile friendly since we output a lot of stuff
to stdout in the make target, so switching it to streamable http by
default.