### PR TITLE
chore!: move logger init to instrumentfx

### DIFF
--- a/config.http.yaml
+++ b/config.http.yaml
@@ -27,3 +27,11 @@ server:
     logscaleURL: ${CHRONOSPHERE_ORG_NAME:""}.logs.chronosphere.io
     # The API token for LogScale if using LogScale for logs.
     logscaleAPIToken: ${LOGSCALE_API_TOKEN:""}
+
+instrument:
+  logs:
+    level: ${LOG_LEVEL:info}
+    outputPaths:
+      - stderr
+    errorOutputPaths:
+      - stderr

--- a/config.sse.yaml
+++ b/config.sse.yaml
@@ -27,3 +27,11 @@ server:
     logscaleURL: ${CHRONOSPHERE_ORG_NAME:""}.logs.chronosphere.io
     # The API token for LogScale if using LogScale for logs.
     logscaleAPIToken: ${LOGSCALE_API_TOKEN:""}
+
+instrument:
+  logs:
+    level: ${LOG_LEVEL:info}
+    outputPaths:
+      - stderr
+    errorOutputPaths:
+      - stderr

--- a/config.yaml
+++ b/config.yaml
@@ -27,3 +27,11 @@ server:
     logscaleURL: ${CHRONOSPHERE_ORG_NAME:""}.logs.chronosphere.io
     # The API token for LogScale if using LogScale for logs.
     logscaleAPIToken: ${LOGSCALE_API_TOKEN:""}
+
+instrument:
+  logs:
+    level: ${LOG_LEVEL:info}
+    outputPaths:
+      - stderr
+    errorOutputPaths:
+      - stderr

--- a/mcp-server/pkg/instrumentfx/instrumentfx.go
+++ b/mcp-server/pkg/instrumentfx/instrumentfx.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Chronosphere Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package instrumentfx is a fx module that provides logs, metrics and tracing integration.
+package instrumentfx
+
+import (
+	"go.uber.org/config"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+)
+
+var Module = fx.Options(
+	fx.Provide(NewInstrument),
+)
+
+type Input struct {
+	fx.In
+
+	ConfigProvider config.Provider
+}
+
+type Result struct {
+	fx.Out
+
+	Logger *zap.Logger
+}
+
+type Config struct {
+	ServiceName string     `yaml:"serviceName"`
+	Logs        zap.Config `yaml:"logs"`
+}
+
+func defaultConfig() Config {
+	return Config{
+		ServiceName: "chrono-mcp",
+		Logs:        zap.NewProductionConfig(),
+	}
+}
+
+func NewInstrument(
+	params Input,
+) (Result, error) {
+	cfg := defaultConfig()
+	if err := params.ConfigProvider.Get("instrument").Populate(&cfg); err != nil {
+		return Result{}, err
+	}
+
+	logger, err := cfg.Logs.Build()
+	if err != nil {
+		return Result{}, err
+	}
+
+	logger.Info("Instrument config",
+		zap.String("serviceName", cfg.ServiceName),
+		zap.String("logLevel", cfg.Logs.Level.String()),
+		zap.Strings("output", cfg.Logs.OutputPaths),
+		zap.Strings("errorOutput", cfg.Logs.ErrorOutputPaths),
+	)
+
+	return Result{
+		Logger: logger,
+	}, nil
+}

--- a/mcp-server/pkg/mcpserverfx/flags.go
+++ b/mcp-server/pkg/mcpserverfx/flags.go
@@ -22,14 +22,12 @@ type Flags struct {
 	apiToken       string
 	orgName        string
 	ConfigFilePath string
-	VerboseLogging bool
 	UseLogScale    bool
 }
 
 // AddFlags adds client flags to a Cobra command.
 func (f *Flags) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.ConfigFilePath, "config-file", "c", "", "The YAML file containing configuration parameters")
-	cmd.Flags().BoolVarP(&f.VerboseLogging, "verbose", "v", false, "Whether verbose logging, including logging requests and responses, should be enabled")
 	cmd.Flags().StringVar(&f.apiToken, "api-token", "", "The client API token used to authenticate to user.")
 	cmd.Flags().StringVar(&f.orgName, "org-name", "", "The name of your team's Chronosphere organization.")
 	cmd.Flags().BoolVar(&f.UseLogScale, "use-logscale", false, "Whether to use LogScale instead of chronosphere logs for log queries. If set, the LogScale API token must be provided via the LOGSCALE_API_TOKEN environment variable.")


### PR DESCRIPTION
Add an instrumentfx module to provide the logger. Will be extending
this to provide

Add yaml configuration for instrumentfx

Remove the `--verbose` option from the command line in favor of
config.yaml file based configuration.