### PR TITLE
ci: bundle a config.yaml with releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,6 +28,7 @@ archives:
     files:
       - README.md
       - LICENSE*
+      - config.yaml
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_


### PR DESCRIPTION
The mcp server requires configuration from config.yaml to run, so bundle
with releases so anyone downloading it doesn't have to start from
scratch.