### PR TITLE
links: don't add empty parameters

### DIFF
--- a/pkg/links/custom.go
+++ b/pkg/links/custom.go
@@ -38,6 +38,9 @@ func (b *CustomBuilder) WithParam(key, value string) *CustomBuilder {
 	if b.params == nil {
 		b.params = url.Values{}
 	}
+	if value == "" {
+		return b
+	}
 	b.params.Add(key, value)
 	return b
 }

--- a/pkg/links/custom_test.go
+++ b/pkg/links/custom_test.go
@@ -60,7 +60,7 @@ func TestCustomBuilder(t *testing.T) {
 		{
 			name:     "with empty parameter value",
 			builder:  builder.Custom("/endpoint").WithParam("empty", ""),
-			expected: "https://custom.chronosphere.io/endpoint?empty=",
+			expected: "https://custom.chronosphere.io/endpoint?",
 		},
 		{
 			name: "with duplicate parameter keys",
@@ -395,7 +395,7 @@ func TestCustomBuilder_ParameterTypes(t *testing.T) {
 				WithParam("space", " ").
 				WithParam("tabs", "\t\t"),
 			expected: map[string][]string{
-				"empty": {""},
+				"empty": nil,
 				"space": {" "},
 				"tabs":  {"\t\t"},
 			},


### PR DESCRIPTION
metric explorer links are sometimes broken when an optional field is
empty such as `matchers[]`. We shouldn't be adding them to the url when
they're empty.