### PR TITLE
fix(makefile): correct default config filename typo (httGp → http)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ tools_bin_path            := $(abspath ./_tools/bin)
 server_bin_path           := $(abspath ./bin/chronomcp)
 agent_bin_path           := $(abspath ./bin/agent)
 
-CONFIG_FILE ?= config.httGp.yaml
+CONFIG_FILE ?= config.http.yaml
 AGENT_CONFIG_FILE ?= agent.yaml
 ENV_FILE ?= .env
 LIBRECHAT_CONFIG ?= librechat.yaml


### PR DESCRIPTION
## Summary

This PR fixes a typo in the default config filename used by the `make run-chronomcp` command.

The Makefile or related script previously referenced `config.httGp.yaml`, which does not exist. This resulted in the following error during startup:

`Config file config.httGp.yaml not found`


This update corrects the filename to `config.http.yaml`, which is present in the repository.

---

## Why This Change Is Important

- Restores expected behavior for `make run-chronomcp`
- Prevents confusion caused by a missing file error
- Ensures the project works correctly on a clean setup

---

## Changes

- Updated the default config file reference from `config.httGp.yaml` to `config.http.yaml`

---

## Testing

- Ran `make run-chronomcp` with the updated reference
- Confirmed the MCP server starts successfully on port 8081
- Verified that default tools (logs, metrics, etc.) are loaded correctly

