### PR TITLE
feat: forward access token cookie

### DIFF
--- a/mcp-server/pkg/authcontext/auth.go
+++ b/mcp-server/pkg/authcontext/auth.go
@@ -19,16 +19,25 @@ import "context"
 
 type sessionAPITokenKey struct{}
 
-// SetSessionAPIToken sets the session API token in the context.
-func SetSessionAPIToken(ctx context.Context, token string) context.Context {
-	return context.WithValue(ctx, sessionAPITokenKey{}, token)
+type SessionCredentials struct {
+	APIToken          string
+	AccessTokenCookie string
+}
+
+func (s SessionCredentials) IsEmpty() bool {
+	return s.APIToken == "" && s.AccessTokenCookie == ""
+}
+
+// SetSessionCredentials sets the session credentials in the context.
+func SetSessionCredentials(ctx context.Context, credentials SessionCredentials) context.Context {
+	return context.WithValue(ctx, sessionAPITokenKey{}, credentials)
 }
 
 // FetchSessionAPIToken retrieves the session API token from the context.
-func FetchSessionAPIToken(ctx context.Context) string {
-	sessionAPIToken, ok := ctx.Value(sessionAPITokenKey{}).(string)
+func FetchSessionAPIToken(ctx context.Context) SessionCredentials {
+	credentials, ok := ctx.Value(sessionAPITokenKey{}).(SessionCredentials)
 	if !ok {
-		return ""
+		return SessionCredentials{}
 	}
-	return sessionAPIToken
+	return credentials
 }

--- a/mcp-server/pkg/authcontext/middleware.go
+++ b/mcp-server/pkg/authcontext/middleware.go
@@ -16,14 +16,27 @@ package authcontext
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
+)
+
+const (
+	_chronoAccessTokenHeaderName = "chrono-accesstoken"
 )
 
 // HTTPInboundContextFunc extracts the Authorization header from the HTTP request and sets it in the context.
 func HTTPInboundContextFunc(ctx context.Context, r *http.Request) context.Context {
 	authValue := strings.ReplaceAll(r.Header.Get("Authorization"), "Bearer ", "")
-	return SetSessionAPIToken(ctx, authValue)
+	cookie, err := r.Cookie(_chronoAccessTokenHeaderName)
+	var cookieValue string
+	if err == nil {
+		cookieValue = cookie.Value
+	}
+	return SetSessionCredentials(ctx, SessionCredentials{
+		APIToken:          authValue,
+		AccessTokenCookie: cookieValue,
+	})
 }
 
 // RoundTripper wraps an http.RoundTripper and adds an Authorization header.
@@ -43,9 +56,10 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Clone the request to avoid modifying the original.
 	req2 := req.Clone(req.Context())
 
-	if authToken := FetchSessionAPIToken(req.Context()); authToken != "" {
-		// forward the api token from context if available
-		req2.Header.Set("Authorization", "Bearer "+authToken)
+	if credentials := FetchSessionAPIToken(req.Context()); !credentials.IsEmpty() {
+		// forward the api token & access token cookie from context if available
+		req2.Header.Set("Authorization", "Bearer "+credentials.APIToken)
+		req2.Header.Set("Cookie", fmt.Sprintf("%s=%s", _chronoAccessTokenHeaderName, credentials.AccessTokenCookie))
 	} else if r.token != "" {
 		req2.Header.Set("Authorization", "Bearer "+r.token)
 	}

--- a/mcp-server/pkg/mcpserver/mcpserver_test.go
+++ b/mcp-server/pkg/mcpserver/mcpserver_test.go
@@ -116,7 +116,9 @@ func TestLoggingTool_mustHandle(t *testing.T) {
 				tool:   tt.tool,
 			}
 
-			ctx := authcontext.SetSessionAPIToken(context.Background(), tt.sessionAPIToken)
+			ctx := authcontext.SetSessionCredentials(context.Background(), authcontext.SessionCredentials{
+				APIToken: tt.sessionAPIToken,
+			})
 			result := lt.mustHandle(ctx, mcp.CallToolRequest{})
 
 			assert.Equal(t, len(tt.expectedContent), len(result.Content), "content length mismatch")


### PR DESCRIPTION
Forward the chronosphere access token cookie from requests. This allows
the mcp server to be called from the chronosphere UI.