### PR TITLE
Fix YAML field name mismatch for `enableClassicDashboards` configuration

### DIFF
--- a/mcp-server/pkg/tools/tools.go
+++ b/mcp-server/pkg/tools/tools.go
@@ -24,7 +24,7 @@ import (
 
 type Config struct {
 	Disabled                []string `yaml:"disabled"`
-	EnableClassicDashboards bool     `yaml:"enable_classic_dashboards"`
+	EnableClassicDashboards bool     `yaml:"enableClassicDashboards"`
 }
 
 type Result struct {


### PR DESCRIPTION
## Problem
The MCP server was failing to start due to a YAML configuration parsing error:

```console
yaml: unmarshal errors: line 9: field enableClassicDashboards not found in type tools.Config
```

The issue was caused by a mismatch between the YAML field name in the configuration file (`enableClassicDashboards`) and the struct tag in the Go code (`enable_classic_dashboards`).

## Solution
Updated the YAML struct tag for `EnableClassicDashboards` field from `enable_classic_dashboards` to `enableClassicDashboards` to match the camelCase naming used in the configuration file.

**Changes:**
```go
// Before
EnableClassicDashboards bool `yaml:"enable_classic_dashboards"`

// After  
EnableClassicDashboards bool `yaml:"enableClassicDashboards"`
```

## Testing

- ✅ Server starts without configuration errors
- ✅ Configuration file is properly parsed
- ✅ enableClassicDashboards setting is correctly loaded from YAML

