### PR TITLE
chore: add test to make sure the server starts up

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/go-openapi/swag v0.23.0
 	github.com/go-openapi/validate v0.24.0
-	github.com/mark3labs/mcp-go v0.32.0
+	github.com/mark3labs/mcp-go v0.34.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/common v0.61.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/mark3labs/mcp-go v0.32.0 h1:fgwmbfL2gbd67obg57OfV2Dnrhs1HtSdlY/i5fn7MU8=
-github.com/mark3labs/mcp-go v0.32.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
+github.com/mark3labs/mcp-go v0.34.0 h1:eWy7WBGvhk6EyAAyVzivTCprE52iXJwNtvHV6Cv3bR0=
+github.com/mark3labs/mcp-go v0.34.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/mcp-server/pkg/cmd/root_test.go
+++ b/mcp-server/pkg/cmd/root_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/chronosphereio/chronosphere-mcp/mcp-server/pkg/mcpserverfx"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestFxStartup(t *testing.T) {
+	tests := []struct {
+		configFile string
+	}{
+		{
+			configFile: "config.yaml",
+		},
+		{
+			configFile: "config.http.yaml",
+		},
+		{
+			configFile: "config.sse.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.configFile, func(t *testing.T) {
+			flags := &mcpserverfx.Flags{
+				ConfigFilePath: "../../../" + tt.configFile,
+			}
+			app := fxtest.New(t, allModules(flags)...).RequireStart()
+			// It can take a small amount of time for the http server to start up, so wait a second
+			// before calling shutdown otherwise we could end up shutting down before the server is initialized.
+			time.Sleep(1 * time.Second)
+			app.RequireStop()
+		})
+	}
+}

--- a/mcp-server/pkg/mcpserverfx/mcpserverfx.go
+++ b/mcp-server/pkg/mcpserverfx/mcpserverfx.go
@@ -90,7 +90,7 @@ func invoke(p params) (*Transports, error) {
 
 	p.LifeCycle.Append(fx.Hook{
 		OnStart: func(_ context.Context) error {
-			go transports.Start(context.Background())
+			transports.Start(context.Background())
 			return nil
 		},
 		OnStop: func(ctx context.Context) error {

--- a/mcp-server/pkg/mcpserverfx/transport.go
+++ b/mcp-server/pkg/mcpserverfx/transport.go
@@ -114,7 +114,7 @@ func (t *Transports) Start(ctx context.Context) {
 			defer t.wg.Done()
 			t.logger.Info("serving stdio transport")
 			if err := t.server.StdioServer().Listen(ctx, os.Stdin, os.Stdout); err != nil {
-				t.logger.Error("error serving stdio transport", zap.Error(err))
+				t.logger.DPanic("error serving stdio transport", zap.Error(err))
 			}
 		}()
 	}
@@ -128,7 +128,7 @@ func (t *Transports) Start(ctx context.Context) {
 				zap.String("address", t.sse.Address),
 				zap.String("baseURL", t.sse.BaseURL))
 			if err := t.sseServer.Start(t.sse.Address); err != nil {
-				t.logger.Error("error serving sse transport", zap.Error(err))
+				t.logger.DPanic("error serving sse transport", zap.Error(err))
 			}
 		}()
 	}


### PR DESCRIPTION
v0.3.2 introduced a bug that caused the server to fail on start up
with the provided config.yaml file which was fixed in https://github.com/chronosphereio/chronosphere-mcp/pull/87

This a test to make sure the server can start up with each of the
example conig files.
