### PR TITLE
use object input for mcp registry variables

### DIFF
--- a/server.json
+++ b/server.json
@@ -22,20 +22,18 @@
           "is_secret": true
         }
       ],
-      "variables": [
-        {
-          "name": "CHRONOSPHERE_ORG_NAME",
+      "variables": {
+        "CHRONOSPHERE_ORG_NAME": {
           "description": "The name of the Chronosphere organization or subdomain",
           "is_required": true,
           "is_secret": false
         },
-        {
-          "name": "CHRONOSPHERE_API_TOKEN",
+        "CHRONOSPHERE_API_TOKEN": {
           "description": "The service account token or personal access token for Chronosphere",
           "is_required": true,
           "is_secret": true
         }
-      ]
+      }
     }
   ]
 }


### PR DESCRIPTION
looks like the "variables" property should be an object according to the
[schema](https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json).