### PR TITLE
fix nil pointer when loading nil optional config

### DIFF
--- a/mcp-server/pkg/cmd/root_test.go
+++ b/mcp-server/pkg/cmd/root_test.go
@@ -13,20 +13,23 @@ func TestFxStartup(t *testing.T) {
 		configFile string
 	}{
 		{
-			configFile: "config.yaml",
+			configFile: "../../../config.yaml",
 		},
 		{
-			configFile: "config.http.yaml",
+			configFile: "../../../config.http.yaml",
 		},
 		{
-			configFile: "config.sse.yaml",
+			configFile: "../../../config.sse.yaml",
+		},
+		{
+			configFile: "testdata/config.nil-tools.yaml",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.configFile, func(t *testing.T) {
 			flags := &mcpserverfx.Flags{
-				ConfigFilePath: "../../../" + tt.configFile,
+				ConfigFilePath: tt.configFile,
 			}
 			app := fxtest.New(t, allModules(flags)...).RequireStart()
 			// It can take a small amount of time for the http server to start up, so wait a second

--- a/mcp-server/pkg/cmd/testdata/config.nil-tools.yaml
+++ b/mcp-server/pkg/cmd/testdata/config.nil-tools.yaml
@@ -1,0 +1,19 @@
+server:
+  transport:
+    stdio:
+      enabled: true
+
+  # Intentionally omitting tools section to test nil handling
+
+  chronosphere:
+    apiURL: https://${CHRONOSPHERE_ORG_NAME:""}.chronosphere.io
+    apiToken: ${CHRONOSPHERE_API_TOKEN:""}
+    useLogscale: false
+
+instrument:
+  logs:
+    level: ${LOG_LEVEL:info}
+    outputPaths:
+      - stderr
+    errorOutputPaths:
+      - stderr

--- a/mcp-server/pkg/mcpserverfx/config.go
+++ b/mcp-server/pkg/mcpserverfx/config.go
@@ -47,6 +47,10 @@ func parseConfig(cfgProvider config.Provider, flags *Flags) (configResult, error
 
 	mergeConfig(&cfg, flags)
 
+	if cfg.Tools == nil {
+		cfg.Tools = &tools.Config{}
+	}
+
 	if err := validator.Validate(cfg); err != nil {
 		return configResult{}, fmt.Errorf("failed to validate config: %w", err)
 	}


### PR DESCRIPTION
Tools config is optional, but the server crashes with a nil pointer
exception if it starts up without it defined in yaml. This fixes that.

Also fixes issue where logscaleURL is required to be set even if
enableLogscale is false.

Fixes issue https://github.com/chronosphereio/chronosphere-mcp/issues/107