### PR TITLE
Add Docker support for MCP server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [ "main" ]
+    tags:
+      - 'v*.*.*'
   pull_request:
     # No branch targets so this runs on all PRs including stacked ones.
 
@@ -66,3 +68,76 @@ jobs:
 
       - name: Run tests
         run: go test ./... -v
+
+  docker-build:
+    name: Docker Build Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: chronomcp:test
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            GIT_COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  docker-push:
+    name: Docker Push
+    runs-on: ubuntu-latest
+    if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.event_name == 'push'
+    needs: [build, golangci, test, docker-build]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            GIT_COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,63 @@
+# Build stage
+FROM golang:1.23.4-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git make
+
+# Set working directory
+WORKDIR /build
+
+# Copy go module files
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the MCP server binary with version information
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+RUN go build \
+    -ldflags="-X github.com/chronosphereio/chronosphere-mcp/pkg/version.Version=${VERSION} \
+              -X github.com/chronosphereio/chronosphere-mcp/pkg/version.BuildDate=${BUILD_DATE} \
+              -X github.com/chronosphereio/chronosphere-mcp/pkg/version.GitCommit=${GIT_COMMIT}" \
+    -o /build/bin/chronomcp \
+    ./mcp-server
+
+# Runtime stage
+FROM alpine:3.20
+
+# Install runtime dependencies
+RUN apk add --no-cache ca-certificates && \
+    addgroup -g 1001 chronosphere && \
+    adduser -D -s /bin/sh -u 1001 -G chronosphere chronosphere
+
+# Set working directory
+WORKDIR /app
+
+# Copy binary from builder stage
+COPY --from=builder /build/bin/chronomcp /app/chronomcp
+
+# Copy default configuration file (optional - can be overridden via volume mount)
+COPY config.http.yaml /app/config.yaml
+
+# Change ownership to non-root user
+RUN chown -R chronosphere:chronosphere /app
+
+# Switch to non-root user
+USER chronosphere
+
+# Expose HTTP MCP server port (default from config.http.yaml)
+EXPOSE 8081
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD pgrep chronomcp || exit 1
+
+# Set default command
+# Users can override config file via: docker run -v $(pwd)/custom-config.yaml:/app/config.yaml
+ENTRYPOINT ["/app/chronomcp"]
+CMD ["--config", "/app/config.yaml"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,35 @@ make chronomcp
 }
 ```
 
+### Building with Docker
+Build the Docker image with version information:
+```sh
+docker build \
+  --build-arg VERSION=$(git describe --tags --always --dirty) \
+  --build-arg GIT_COMMIT=$(git rev-parse HEAD) \
+  --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+  -t chronomcp:latest .
+```
+
+Run the container in MCP streamable HTTP mode:
+```sh
+docker run -p 8081:8081 \
+  -e CHRONOSPHERE_ORG_NAME=<your-org> \
+  -e CHRONOSPHERE_API_TOKEN=<your-token> \
+  chronomcp:latest
+```
+
+To use a custom configuration file:
+```sh
+docker run -p 8081:8081 \
+  -v $(pwd)/custom-config.yaml:/app/config.yaml \
+  -e CHRONOSPHERE_ORG_NAME=<your-org> \
+  -e CHRONOSPHERE_API_TOKEN=<your-token> \
+  chronomcp:latest
+```
+
+The container exposes the MCP server on port 8081 by default using HTTP transport for streamable communication.
+
 ## Developing
 ### Running the server
 #### Authentication to Chronosphere


### PR DESCRIPTION
## Summary
  Add Docker support for building and running the Chronosphere MCP server in streamable HTTP mode with automated CI/CD integration.

## Changes
- **Dockerfile**: Generic multi-stage build with version injection support
- **GitHub Actions CI**: Docker build testing and automated publishing workflow
- **README Documentation**: Docker build and run instructions

## Docker Features
- **Multi-stage build**: Optimized image size with separate build and runtime stages
- **Security**: Non-root user execution (UID 1001)
- **Version injection**: Build args for `VERSION`, `GIT_COMMIT`, and `BUILD_DATE`
- **Health checks**: Process monitoring with 30s intervals
- **Configuration**: Volume-mountable config files for custom setups
- **HTTP transport**: Streamable MCP mode on port 8081 by default

## CI/CD Integration

### `docker-build` Job (All Runs)
- Runs on all PRs and pushes
- Tests Docker image builds without publishing
- Uses GitHub Actions cache for performance
- Validates Dockerfile on every change

### `docker-push` Job (Main Branch & Tags)
- Publishes to GitHub Container Registry (`ghcr.io`)
- Conditional: Only runs on `main` branch merges and version tags
- Depends on all tests passing: `[build, golangci, test, docker-build]`
- Automatic authentication via `GITHUB_TOKEN`

## Image Tags Strategy

**Version Tag** (e.g., `v0.3.5`):
- `ghcr.io/chronosphereio/chronosphere-mcp:v0.3.5`
- `ghcr.io/chronosphereio/chronosphere-mcp:0.3.5`
- `ghcr.io/chronosphereio/chronosphere-mcp:0.3`
- `ghcr.io/chronosphereio/chronosphere-mcp:<commit-sha>`
- `ghcr.io/chronosphereio/chronosphere-mcp:latest`

**Main Branch Push**:
- `ghcr.io/chronosphereio/chronosphere-mcp:<commit-sha>`
- `ghcr.io/chronosphereio/chronosphere-mcp:latest`

## Usage

### Build Locally
```bash
docker build \
  --build-arg VERSION=$(git describe --tags --always --dirty) \
  --build-arg GIT_COMMIT=$(git rev-parse HEAD) \
  --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
  -t chronomcp:latest .

Run Container

docker run -p 8081:8081 \
  -e CHRONOSPHERE_ORG_NAME=<your-org> \
  -e CHRONOSPHERE_API_TOKEN=<your-token> \
  chronomcp:latest

Custom Configuration

docker run -p 8081:8081 \
  -v $(pwd)/custom-config.yaml:/app/config.yaml \
  -e CHRONOSPHERE_ORG_NAME=<your-org> \
  -e CHRONOSPHERE_API_TOKEN=<your-token> \
  chronomcp:latest

Pull from GHCR (After Merge)

docker pull ghcr.io/chronosphereio/chronosphere-mcp:latest

Testing

Tested with:
- Docker build completes successfully
- Binary runs and serves MCP on port 8081
- Health check validates process running
- Config file mounting works correctly
- Non-root user execution verified

Notes

- Based on existing project patterns and Go 1.23.4 requirements
- Compatible with MCP inspector debugging workflow
- No breaking changes to existing build/run processes