### PR TITLE
feat: add opt-in dashboard write tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Use this header to hide specific tools from the tool list exposed to your MCP cl
 - **Example value**: `query_logs_range,render_prometheus_range_query`
 - **Notes**: whitespace is ignored; unknown tool names are ignored
 
+#### Enable writes (`X-Chrono-MCP-Enable-Writes`)
+Write tools are hidden and cannot be called by default. The server operator must first permit writes with
+`server.tools.enableWrites: true`. HTTP and SSE clients must additionally set this header to `true`; the header cannot
+override a disabled server setting. Other values do not enable writes.
+
+Stdio has no request headers, so the server setting alone enables writes for that transport. The Chronosphere credentials
+used by the server must still authorize the underlying API operation.
+
 #### Cursor/VSCode
 ```json
 {
@@ -153,6 +161,7 @@ The MCP project provides an inspector useful for directly calling tools APIs. To
 | configapi | list_recording_rules | List recording-rules resources |
 | configapi | list_rollup_rules | List rollup-rules resources |
 | configapi | list_slos | List slos resources |
+| configapi | update_dashboard | Replace a dashboard identified by slug. Use dry_run to validate without saving. |
 | events | get_events_metadata | List properties you can query on events |
 | events | list_events | List events from a given query |
 | events | list_events_label_values | List values for a given label name |

--- a/config.http.yaml
+++ b/config.http.yaml
@@ -14,6 +14,10 @@ server:
   tools:
     # List of tools to disable if you don't want to serve them to the client/host.
     disabled: []
+    # Write tools are disabled by default. This setting permits writes; HTTP clients must
+    # also opt in per request with
+    # X-Chrono-MCP-Enable-Writes: true.
+    enableWrites: false
 
   chronosphere:
     apiURL: https://${CHRONOSPHERE_ORG_NAME:""}.chronosphere.io

--- a/config.sse.yaml
+++ b/config.sse.yaml
@@ -14,6 +14,10 @@ server:
   tools:
     # List of tools to disable if you don't want to serve them to the client/host.
     disabled: []
+    # Write tools are disabled by default. This setting permits writes; SSE clients must
+    # also opt in per request with
+    # X-Chrono-MCP-Enable-Writes: true.
+    enableWrites: false
 
   chronosphere:
     apiURL: https://${CHRONOSPHERE_ORG_NAME:""}.chronosphere.io

--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,8 @@ server:
     # Classic dashboards are a legacy dashboard format. Enable this if you still use
     # classic dashboards.
     enableClassicDashboards: false
+    # Write tools are disabled by default. Enable this for all transports, including stdio.
+    enableWrites: false
 
   chronosphere:
     apiURL: https://${CHRONOSPHERE_ORG_NAME:""}.chronosphere.io

--- a/mcp-server/pkg/authcontext/auth.go
+++ b/mcp-server/pkg/authcontext/auth.go
@@ -19,6 +19,7 @@ import "context"
 
 type sessionAPITokenKey struct{}
 type disabledToolsKey struct{}
+type writesEnabledKey struct{}
 
 type SessionCredentials struct {
 	APIToken          string
@@ -55,4 +56,26 @@ func FetchDisabledTools(ctx context.Context) map[string]struct{} {
 		return nil
 	}
 	return disabledTools
+}
+
+// SetWritesEnabled records whether write tools are enabled for the request.
+func SetWritesEnabled(ctx context.Context, enabled bool) context.Context {
+	return context.WithValue(ctx, writesEnabledKey{}, enabled)
+}
+
+// FetchWritesEnabled reports whether write tools are enabled for the request.
+func FetchWritesEnabled(ctx context.Context) bool {
+	enabled, ok := ctx.Value(writesEnabledKey{}).(bool)
+	return ok && enabled
+}
+
+// WritesEnabled reports whether the server and, when present, request both enable writes.
+// HTTP and SSE middleware always records a request preference. Stdio has no request
+// preference, so the server setting alone controls writes for that transport.
+func WritesEnabled(ctx context.Context, serverEnabled bool) bool {
+	if !serverEnabled {
+		return false
+	}
+	requestEnabled, hasRequestPreference := ctx.Value(writesEnabledKey{}).(bool)
+	return !hasRequestPreference || requestEnabled
 }

--- a/mcp-server/pkg/authcontext/middleware.go
+++ b/mcp-server/pkg/authcontext/middleware.go
@@ -28,6 +28,7 @@ import (
 const (
 	_chronoAccessTokenHeaderName = "chrono-accesstoken"
 	_disableToolsHeaderName      = "X-Chrono-MCP-Disable-Tools"
+	_enableWritesHeaderName      = "X-Chrono-MCP-Enable-Writes"
 )
 
 // HTTPInboundContextFunc extracts the Authorization header from the HTTP request and sets it in the context.
@@ -56,6 +57,9 @@ func HTTPInboundContextFunc(ctx context.Context, r *http.Request) context.Contex
 		}
 		ctx = SetDisabledTools(ctx, disabledTools)
 	}
+
+	enableWritesHeader := strings.TrimSpace(r.Header.Get(_enableWritesHeaderName))
+	ctx = SetWritesEnabled(ctx, strings.EqualFold(enableWritesHeader, "true"))
 
 	return ctx
 }

--- a/mcp-server/pkg/authcontext/middleware_test.go
+++ b/mcp-server/pkg/authcontext/middleware_test.go
@@ -92,6 +92,64 @@ func TestHTTPInboundContextFunc_DisabledTools(t *testing.T) {
 	}
 }
 
+func TestHTTPInboundContextFunc_EnableWrites(t *testing.T) {
+	tests := []struct {
+		name        string
+		headerValue string
+		expected    bool
+	}{
+		{name: "missing header"},
+		{name: "true", headerValue: "true", expected: true},
+		{name: "case insensitive", headerValue: "TRUE", expected: true},
+		{name: "surrounding whitespace", headerValue: "  true  ", expected: true},
+		{name: "false", headerValue: "false"},
+		{name: "numeric value", headerValue: "1"},
+		{name: "arbitrary value", headerValue: "yes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.headerValue != "" {
+				req.Header.Set("X-Chrono-MCP-Enable-Writes", tt.headerValue)
+			}
+
+			ctx := HTTPInboundContextFunc(t.Context(), req)
+
+			assert.Equal(t, tt.expected, FetchWritesEnabled(ctx))
+		})
+	}
+}
+
+func TestWritesEnabled(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverEnabled  bool
+		requestEnabled *bool
+		expected       bool
+	}{
+		{name: "disabled by default"},
+		{name: "stdio enabled by server", serverEnabled: true, expected: true},
+		{name: "header cannot override server", requestEnabled: boolPointer(true)},
+		{name: "HTTP requires header", serverEnabled: true, requestEnabled: new(bool)},
+		{name: "HTTP enabled by server and header", serverEnabled: true, requestEnabled: boolPointer(true), expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			if tt.requestEnabled != nil {
+				ctx = SetWritesEnabled(ctx, *tt.requestEnabled)
+			}
+			assert.Equal(t, tt.expected, WritesEnabled(ctx, tt.serverEnabled))
+		})
+	}
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}
+
 func TestHTTPInboundContextFunc_Credentials(t *testing.T) {
 	tests := []struct {
 		name                string

--- a/mcp-server/pkg/mcpserver/mcpserver.go
+++ b/mcp-server/pkg/mcpserver/mcpserver.go
@@ -44,6 +44,7 @@ type Server struct {
 type Options struct {
 	Logger         *zap.Logger
 	DisabledTools  map[string]struct{}
+	EnableWrites   bool
 	ToolGroups     []tools.MCPTools
 	TracerProvider trace.TracerProvider
 	MeterProvider  *metric.MeterProvider
@@ -53,6 +54,15 @@ func NewServer(
 	opts Options,
 	logger *zap.Logger,
 ) (*Server, error) {
+	writeToolNames := make(map[string]struct{})
+	for _, group := range opts.ToolGroups {
+		for _, tool := range group.MCPTools() {
+			if tool.Write {
+				writeToolNames[tool.Metadata.Name] = struct{}{}
+			}
+		}
+	}
+
 	// Build server options
 	serverOptions := []server.ServerOption{
 		server.WithResourceCapabilities(true, true),
@@ -62,19 +72,9 @@ func NewServer(
 		server.WithResourceHandlerMiddleware(instrumentfx.ResourceTracingMiddleware(opts.TracerProvider)),
 		server.WithResourceHandlerMiddleware(instrumentfx.ResourceMetricsMiddleware(opts.MeterProvider)),
 		server.WithLogging(),
-		// Filter tools based on disabled tools from request context
+		// Filter tools based on request context.
 		server.WithToolFilter(func(ctx context.Context, tools []mcp.Tool) []mcp.Tool {
-			disabledTools := authcontext.FetchDisabledTools(ctx)
-			if len(disabledTools) == 0 {
-				return tools
-			}
-			filtered := make([]mcp.Tool, 0, len(tools))
-			for _, tool := range tools {
-				if _, disabled := disabledTools[tool.Name]; !disabled {
-					filtered = append(filtered, tool)
-				}
-			}
-			return filtered
+			return filterTools(ctx, tools, writeToolNames, opts.EnableWrites)
 		}),
 	}
 
@@ -102,8 +102,9 @@ func NewServer(
 			}
 
 			wrapper := &loggingTool{
-				logger: logger,
-				tool:   tool,
+				logger:       logger,
+				tool:         tool,
+				enableWrites: opts.EnableWrites,
 			}
 			s.server.AddTool(tool.MCPGoTool(), wrapper.handle)
 		}
@@ -114,6 +115,31 @@ func NewServer(
 	}
 
 	return s, nil
+}
+
+func filterTools(
+	ctx context.Context,
+	mcpTools []mcp.Tool,
+	writeToolNames map[string]struct{},
+	enableWrites bool,
+) []mcp.Tool {
+	disabledTools := authcontext.FetchDisabledTools(ctx)
+	writesEnabled := authcontext.WritesEnabled(ctx, enableWrites)
+	if len(disabledTools) == 0 && writesEnabled {
+		return mcpTools
+	}
+
+	filtered := make([]mcp.Tool, 0, len(mcpTools))
+	for _, tool := range mcpTools {
+		if _, disabled := disabledTools[tool.Name]; disabled {
+			continue
+		}
+		if _, write := writeToolNames[tool.Name]; write && !writesEnabled {
+			continue
+		}
+		filtered = append(filtered, tool)
+	}
+	return filtered
 }
 
 func (s *Server) StdioServer() *server.StdioServer {
@@ -140,8 +166,9 @@ func (s *Server) StreamableHTTPServer(options ...server.StreamableHTTPOption) *s
 var _ server.ToolHandlerFunc = (*loggingTool)(nil).handle
 
 type loggingTool struct {
-	logger *zap.Logger
-	tool   tools.MCPTool
+	logger       *zap.Logger
+	tool         tools.MCPTool
+	enableWrites bool
 }
 
 func (t *loggingTool) handle(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -168,6 +195,12 @@ func (t *loggingTool) handle(ctx context.Context, request mcp.CallToolRequest) (
 }
 
 func (t *loggingTool) mustHandle(ctx context.Context, request mcp.CallToolRequest) *mcp.CallToolResult {
+	if t.tool.Write && !authcontext.WritesEnabled(ctx, t.enableWrites) {
+		return mcp.NewToolResultError(
+			"write tools are disabled; enable server.tools.enableWrites and, for HTTP/SSE, X-Chrono-MCP-Enable-Writes",
+		)
+	}
+
 	resp, err := t.tool.Handler(ctx, request)
 	if err != nil {
 		t.logger.Info("received error from handler",

--- a/mcp-server/pkg/mcpserver/mcpserver_test.go
+++ b/mcp-server/pkg/mcpserver/mcpserver_test.go
@@ -299,6 +299,136 @@ func TestServer_DynamicToolDisabling(t *testing.T) {
 	}
 }
 
+func TestFilterTools_WriteTools(t *testing.T) {
+	allTools := []mcp.Tool{
+		{Name: "get_dashboard"},
+		{Name: "update_dashboard"},
+	}
+	writeToolNames := map[string]struct{}{
+		"update_dashboard": {},
+	}
+	tests := []struct {
+		name                 string
+		configEnabled        bool
+		hasRequestPreference bool
+		headerEnabled        bool
+		expectedTools        []mcp.Tool
+		disabledTools        map[string]struct{}
+	}{
+		{
+			name:          "writes disabled by default",
+			expectedTools: allTools[:1],
+		},
+		{
+			name:          "stdio writes enabled by config",
+			configEnabled: true,
+			expectedTools: allTools,
+		},
+		{
+			name:                 "header cannot override disabled server",
+			hasRequestPreference: true,
+			headerEnabled:        true,
+			expectedTools:        allTools[:1],
+		},
+		{
+			name:                 "HTTP writes require header",
+			configEnabled:        true,
+			hasRequestPreference: true,
+			expectedTools:        allTools[:1],
+		},
+		{
+			name:                 "HTTP writes enabled by config and header",
+			configEnabled:        true,
+			hasRequestPreference: true,
+			headerEnabled:        true,
+			expectedTools:        allTools,
+		},
+		{
+			name:          "explicit tool disable still wins",
+			configEnabled: true,
+			disabledTools: map[string]struct{}{"update_dashboard": {}},
+			expectedTools: allTools[:1],
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			if tt.hasRequestPreference {
+				ctx = authcontext.SetWritesEnabled(ctx, tt.headerEnabled)
+			}
+			if tt.disabledTools != nil {
+				ctx = authcontext.SetDisabledTools(ctx, tt.disabledTools)
+			}
+
+			assert.Equal(t, tt.expectedTools, filterTools(ctx, allTools, writeToolNames, tt.configEnabled))
+		})
+	}
+}
+
+func TestLoggingTool_WriteGate(t *testing.T) {
+	handlerCalled := false
+	writeTool := tools.MCPTool{
+		Write: true,
+		Handler: func(_ context.Context, _ mcp.CallToolRequest) (*tools.Result, error) {
+			handlerCalled = true
+			return &tools.Result{TextContent: "updated"}, nil
+		},
+	}
+
+	t.Run("disabled", func(t *testing.T) {
+		handlerCalled = false
+		result := (&loggingTool{
+			logger: zap.NewNop(),
+			tool:   writeTool,
+		}).mustHandle(t.Context(), mcp.CallToolRequest{})
+
+		assert.False(t, handlerCalled)
+		assert.Equal(t, mcp.NewToolResultError(
+			"write tools are disabled; enable server.tools.enableWrites and, for HTTP/SSE, X-Chrono-MCP-Enable-Writes",
+		).Content, result.Content)
+	})
+
+	t.Run("stdio enabled by config", func(t *testing.T) {
+		handlerCalled = false
+		result := (&loggingTool{
+			logger:       zap.NewNop(),
+			tool:         writeTool,
+			enableWrites: true,
+		}).mustHandle(t.Context(), mcp.CallToolRequest{})
+
+		assert.True(t, handlerCalled)
+		assert.Equal(t, []mcp.Content{mcp.NewTextContent("updated")}, result.Content)
+	})
+
+	t.Run("header cannot override disabled server", func(t *testing.T) {
+		handlerCalled = false
+		ctx := authcontext.SetWritesEnabled(t.Context(), true)
+		result := (&loggingTool{
+			logger: zap.NewNop(),
+			tool:   writeTool,
+		}).mustHandle(ctx, mcp.CallToolRequest{})
+
+		assert.False(t, handlerCalled)
+		assert.Equal(t, mcp.NewToolResultError(
+			"write tools are disabled; enable server.tools.enableWrites and, for HTTP/SSE, X-Chrono-MCP-Enable-Writes",
+		).Content, result.Content)
+	})
+
+	t.Run("HTTP enabled by config and header", func(t *testing.T) {
+		handlerCalled = false
+		ctx := authcontext.SetWritesEnabled(t.Context(), true)
+		result := (&loggingTool{
+			logger:       zap.NewNop(),
+			tool:         writeTool,
+			enableWrites: true,
+		}).mustHandle(ctx, mcp.CallToolRequest{})
+
+		assert.True(t, handlerCalled)
+		assert.Equal(t, []mcp.Content{mcp.NewTextContent("updated")}, result.Content)
+	})
+}
+
 type mockToolGroup struct {
 	tools []tools.MCPTool
 }

--- a/mcp-server/pkg/mcpserverfx/mcpserverfx.go
+++ b/mcp-server/pkg/mcpserverfx/mcpserverfx.go
@@ -77,6 +77,7 @@ func invoke(p params) (*Transports, error) {
 			Logger:         p.Logger,
 			ToolGroups:     p.ToolGroups,
 			DisabledTools:  disabledTools,
+			EnableWrites:   cfg.Tools.EnableWrites,
 			TracerProvider: p.TracerProvider,
 			MeterProvider:  p.MeterProvider,
 		},

--- a/mcp-server/pkg/tools/configapi/configapi.go
+++ b/mcp-server/pkg/tools/configapi/configapi.go
@@ -54,6 +54,7 @@ func (t *Tools) MCPTools() []tools.MCPTool {
 	mcpTools := []tools.MCPTool{
 		configv1.GetDashboard(t.client, t.logger),
 		configv1.ListDashboards(t.client, t.logger),
+		UpdateDashboard(t.client),
 		configv1.GetDropRule(t.client, t.logger),
 		configv1.ListDropRules(t.client, t.logger),
 		configv1.GetMappingRule(t.client, t.logger),

--- a/mcp-server/pkg/tools/configapi/update_dashboard.go
+++ b/mcp-server/pkg/tools/configapi/update_dashboard.go
@@ -1,0 +1,140 @@
+// Copyright 2025 Chronosphere Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configapi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/chronosphereio/chronosphere-mcp/generated/configv1/configv1"
+	dashboardapi "github.com/chronosphereio/chronosphere-mcp/generated/configv1/configv1/dashboard"
+	"github.com/chronosphereio/chronosphere-mcp/generated/configv1/models"
+	"github.com/chronosphereio/chronosphere-mcp/mcp-server/pkg/tools"
+	"github.com/chronosphereio/chronosphere-mcp/mcp-server/pkg/tools/pkg/params"
+)
+
+// UpdateDashboard returns a tool that replaces a dashboard identified by slug.
+func UpdateDashboard(api *configv1.ConfigV1API) tools.MCPTool {
+	return tools.MCPTool{
+		Metadata: tools.NewMetadata("update_dashboard",
+			mcp.WithDescription("Replace a dashboard identified by slug. Use dry_run to validate without saving."),
+			mcp.WithReadOnlyHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(true),
+			mcp.WithIdempotentHintAnnotation(true),
+			mcp.WithOpenWorldHintAnnotation(true),
+			mcp.WithString("slug",
+				mcp.Description("Slug of the dashboard to update."),
+				mcp.Required(),
+			),
+			mcp.WithObject("dashboard",
+				mcp.Description("Complete replacement dashboard. Include all fields that should be retained."),
+				mcp.Properties(map[string]any{
+					"slug": map[string]any{
+						"type":        "string",
+						"description": "Dashboard slug. It cannot be changed after creation.",
+					},
+					"name": map[string]any{
+						"type":        "string",
+						"description": "Dashboard name.",
+					},
+					"dashboard_json": map[string]any{
+						"type":        "string",
+						"description": "Raw JSON string containing the dashboard definition.",
+					},
+					"collection_slug": map[string]any{
+						"type":        "string",
+						"description": "Optional slug of the collection containing the dashboard.",
+					},
+					"collection": map[string]any{
+						"type":        "object",
+						"description": "Optional collection reference.",
+						"properties": map[string]any{
+							"slug": map[string]any{
+								"type": "string",
+							},
+							"type": map[string]any{
+								"type": "string",
+								"enum": []string{"SIMPLE", "SERVICE"},
+							},
+						},
+						"additionalProperties": false,
+					},
+					"labels": map[string]any{
+						"type":        "object",
+						"description": "Dashboard labels.",
+						"additionalProperties": map[string]any{
+							"type": "string",
+						},
+					},
+				}),
+				mcp.AdditionalProperties(false),
+				mcp.Required(),
+			),
+			mcp.WithBoolean("dry_run",
+				mcp.Description("Validate the dashboard without creating or updating it."),
+			),
+			mcp.WithBoolean("create_if_missing",
+				mcp.Description("Create the dashboard when the path slug does not exist."),
+			),
+		),
+		Write: true,
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*tools.Result, error) {
+			slug, err := params.String(request, "slug", true, "")
+			if err != nil {
+				return nil, err
+			}
+			dashboard, err := params.Object(request, "dashboard", true, models.Configv1Dashboard{})
+			if err != nil {
+				return nil, err
+			}
+			if dashboard.Slug != "" && dashboard.Slug != slug {
+				return nil, fmt.Errorf("dashboard slug %q must match path slug %q", dashboard.Slug, slug)
+			}
+			dashboard.Slug = slug
+			if dashboard.Name == "" {
+				return nil, fmt.Errorf("dashboard.name cannot be empty")
+			}
+			if dashboard.DashboardJSON == "" {
+				return nil, fmt.Errorf("dashboard.dashboard_json cannot be empty")
+			}
+			dryRun, err := params.Bool(request, "dry_run", false, false)
+			if err != nil {
+				return nil, err
+			}
+			createIfMissing, err := params.Bool(request, "create_if_missing", false, false)
+			if err != nil {
+				return nil, err
+			}
+
+			resp, err := api.Dashboard.UpdateDashboard(&dashboardapi.UpdateDashboardParams{
+				Context: ctx,
+				Slug:    slug,
+				Body: &models.ConfigV1UpdateDashboardBody{
+					Dashboard:       &dashboard,
+					DryRun:          dryRun,
+					CreateIfMissing: createIfMissing,
+				},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to call UpdateDashboard: %w", err)
+			}
+			return &tools.Result{
+				JSONContent: resp.Payload,
+			}, nil
+		},
+	}
+}

--- a/mcp-server/pkg/tools/configapi/update_dashboard_test.go
+++ b/mcp-server/pkg/tools/configapi/update_dashboard_test.go
@@ -1,0 +1,194 @@
+// Copyright 2025 Chronosphere Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/chronosphereio/chronosphere-mcp/generated/configv1/configv1"
+	"github.com/chronosphereio/chronosphere-mcp/generated/configv1/models"
+)
+
+func TestUpdateDashboard(t *testing.T) {
+	var capturedBody models.ConfigV1UpdateDashboardBody
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/config/dashboards/test-dashboard", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{
+			"dashboard": {
+				"slug": "test-dashboard",
+				"name": "Updated dashboard",
+				"dashboard_json": "{\"widgets\":[]}"
+			}
+		}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	tool := UpdateDashboard(newConfigV1TestClient(server))
+	result, err := tool.Handler(t.Context(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "update_dashboard",
+			Arguments: map[string]any{
+				"slug": "test-dashboard",
+				"dashboard": map[string]any{
+					"name":            "Updated dashboard",
+					"dashboard_json":  `{"widgets":[]}`,
+					"collection_slug": "team-dashboards",
+					"labels": map[string]any{
+						"team": "platform",
+					},
+				},
+				"dry_run":           true,
+				"create_if_missing": true,
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	response, ok := result.JSONContent.(*models.Configv1UpdateDashboardResponse)
+	require.True(t, ok)
+	require.NotNil(t, response.Dashboard)
+	assert.Equal(t, "test-dashboard", response.Dashboard.Slug)
+
+	require.NotNil(t, capturedBody.Dashboard)
+	assert.Equal(t, "test-dashboard", capturedBody.Dashboard.Slug)
+	assert.Equal(t, "Updated dashboard", capturedBody.Dashboard.Name)
+	assert.Equal(t, `{"widgets":[]}`, capturedBody.Dashboard.DashboardJSON)
+	assert.Equal(t, "team-dashboards", capturedBody.Dashboard.CollectionSlug)
+	assert.Equal(t, map[string]string{"team": "platform"}, capturedBody.Dashboard.Labels)
+	assert.True(t, capturedBody.DryRun)
+	assert.True(t, capturedBody.CreateIfMissing)
+}
+
+func TestUpdateDashboardValidation(t *testing.T) {
+	tool := UpdateDashboard(configv1.NewHTTPClient(nil))
+	tests := []struct {
+		name      string
+		arguments map[string]any
+		errorText string
+	}{
+		{
+			name: "missing dashboard",
+			arguments: map[string]any{
+				"slug": "test-dashboard",
+			},
+			errorText: "missing required parameter: dashboard",
+		},
+		{
+			name: "mismatched slug",
+			arguments: map[string]any{
+				"slug": "test-dashboard",
+				"dashboard": map[string]any{
+					"slug":           "other-dashboard",
+					"name":           "Updated dashboard",
+					"dashboard_json": "{}",
+				},
+			},
+			errorText: `dashboard slug "other-dashboard" must match path slug "test-dashboard"`,
+		},
+		{
+			name: "missing name",
+			arguments: map[string]any{
+				"slug": "test-dashboard",
+				"dashboard": map[string]any{
+					"dashboard_json": "{}",
+				},
+			},
+			errorText: "dashboard.name cannot be empty",
+		},
+		{
+			name: "missing dashboard JSON",
+			arguments: map[string]any{
+				"slug": "test-dashboard",
+				"dashboard": map[string]any{
+					"name": "Updated dashboard",
+				},
+			},
+			errorText: "dashboard.dashboard_json cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tool.Handler(t.Context(), mcp.CallToolRequest{
+				Params: mcp.CallToolParams{
+					Name:      "update_dashboard",
+					Arguments: tt.arguments,
+				},
+			})
+			require.ErrorContains(t, err, tt.errorText)
+		})
+	}
+}
+
+func TestUpdateDashboardAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, err := w.Write([]byte(`{"code":400,"message":"invalid dashboard"}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	tool := UpdateDashboard(newConfigV1TestClient(server))
+	_, err := tool.Handler(t.Context(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "update_dashboard",
+			Arguments: map[string]any{
+				"slug": "test-dashboard",
+				"dashboard": map[string]any{
+					"name":           "Updated dashboard",
+					"dashboard_json": "{}",
+				},
+			},
+		},
+	})
+
+	require.ErrorContains(t, err, "failed to call UpdateDashboard")
+	require.ErrorContains(t, err, "invalid dashboard")
+}
+
+func TestUpdateDashboardMetadata(t *testing.T) {
+	tool := UpdateDashboard(configv1.NewHTTPClient(nil))
+
+	assert.True(t, tool.Write)
+	require.NotNil(t, tool.Metadata.Annotations.ReadOnlyHint)
+	assert.False(t, *tool.Metadata.Annotations.ReadOnlyHint)
+	require.NotNil(t, tool.Metadata.Annotations.DestructiveHint)
+	assert.True(t, *tool.Metadata.Annotations.DestructiveHint)
+	require.NotNil(t, tool.Metadata.Annotations.IdempotentHint)
+	assert.True(t, *tool.Metadata.Annotations.IdempotentHint)
+	require.NotNil(t, tool.Metadata.Annotations.OpenWorldHint)
+	assert.True(t, *tool.Metadata.Annotations.OpenWorldHint)
+}
+
+func newConfigV1TestClient(server *httptest.Server) *configv1.ConfigV1API {
+	transport := configv1.DefaultTransportConfig().
+		WithHost(server.URL[7:]).
+		WithSchemes([]string{"http"})
+	return configv1.NewHTTPClientWithConfig(nil, transport)
+}

--- a/mcp-server/pkg/tools/tools.go
+++ b/mcp-server/pkg/tools/tools.go
@@ -25,6 +25,7 @@ import (
 type Config struct {
 	Disabled                []string `yaml:"disabled"`
 	EnableClassicDashboards bool     `yaml:"enableClassicDashboards"`
+	EnableWrites            bool     `yaml:"enableWrites"`
 }
 
 type Result struct {
@@ -61,6 +62,7 @@ type Session struct {
 type MCPTool struct {
 	Metadata Metadata
 	Handler  Handler
+	Write    bool
 }
 
 func NewMetadata(name string, opts ...mcp.ToolOption) Metadata {


### PR DESCRIPTION
## Summary
- add server-side and per-request opt-ins for write-capable MCP tools
- add a full-replacement `update_dashboard` tool with dry-run and create-if-missing support
- document write enablement and cover gating, request mapping, errors, and annotations with tests

## Test plan
- [x] `GOTOOLCHAIN=go1.25.8 go test ./mcp-server/...`
- [x] `GOTOOLCHAIN=go1.25.8 make chronomcp`
- [x] `GOTOOLCHAIN=go1.25.8 GOFLAGS=\"${GOFLAGS}\" ./_tools/bin/golangci-lint run`